### PR TITLE
incorrect zip code for Fischer F000463 Omaha address

### DIFF
--- a/legislators-district-offices.yaml
+++ b/legislators-district-offices.yaml
@@ -4796,7 +4796,7 @@
     phone: 308-630-2329
     state: NE
     suite: Suite 205
-    zip: '69361'
+    zip: '68154'
   - address: 1110 Circle Dr.
     building: ''
     city: Scottsbluff


### PR DESCRIPTION
was bulk geocoding these addresses and this one did not Geocode because the zip was wrong
source: http://www.fischer.senate.gov/public/index.cfm/office-information