### PR TITLE
Updated and corrected district and legislator data using independent cross reference, lookup script

### DIFF
--- a/congress_lookup.py
+++ b/congress_lookup.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python
+#coding: utf-8
+__author__ = 'stsmith'
+
+# congress_lookup: Look up information about congress from the congress-legislators database
+# See: https://github.com/unitedstates/congress-legislators and https://github.com/TheWalkers/congress-legislators
+
+# The project is in the public domain within the United States, and
+# copyright and related rights in the work worldwide are waived
+# through the CC0 1.0 Universal public domain dedication.
+
+# Author 2017 Steven T. Smith <steve dot t dot smith at gmail dot com>
+
+import argparse as ap, contextlib, errno, fnmatch, os, urllib2, urlparse, yaml
+
+class CongressLookup:
+    '''A class used to lookup legislator properties from the github congress-legislators YAML database.'''
+
+    def __init__(self):
+        self.args = self.parseArgs()
+        self.data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)),self.args.data_dir)
+        self.properties = dict()
+        self.database_load()
+        for prop in self.args.properties: self.lookup_property(prop)
+
+    def parseArgs(self):
+        parser = ap.ArgumentParser()
+        parser.add_argument('properties', metavar='PROPS', type=str, nargs='+',
+                            help='Properties to look up')
+        parser.add_argument('-c', '--committee', help="Committee name (wildcard)", type=str, default=None)
+        parser.add_argument('-n', '--last-name', help="Last name of legislator (wildcard)", type=str, default=None)
+        parser.add_argument('-d', '--data-dir', help="Database directory", type=str, default='.')
+        parser.add_argument('-r', '--repo', help="GitHub repo URL", type=str, default='https://github.com/essandess/congress-legislators/')
+        parser.add_argument('-D', '--download', help="Download data", action='store_true', default=True)
+        parser.add_argument('-g', '--debug', help="Debug flag", action='store_true')
+        return parser.parse_args()
+
+    def lookup_property(self,property):
+        if self.args.committee is not None:
+            self.lookup_by_committee(property)
+        if self.args.last_name is not None:
+            self.lookup_by_lastname(property)
+
+    def lookup_by_committee(self,property):
+        for comm in (comm for comm in self.committees if self.inclusive_wildcard_match(comm['name'],self.args.committee)):
+            if self.args.debug: print(comm)
+            print('"{}" member properties:'.format(comm['name'].encode('utf-8')))
+            members = self.membership[comm['thomas_id']] if comm['thomas_id'] in self.membership else []
+            for member in members: self.lookup_by_member(property,member)
+
+    def inclusive_wildcard_match(self,name,pat):
+        if any(c in pat for c in '*?[]'):	# a wildcard pattern
+            # prepend or append a * for inclusiveness if not already there
+            if pat[0] is not '*': pat = '*' + pat
+            if pat[-1] is not '*': pat = pat + '*'
+        else:					# not a wildcard
+            pat = '*' + pat + '*'
+        return fnmatch.fnmatch(name,pat)
+
+    def lookup_by_member(self,property,member):
+        for leg in ( leg for leg in self.legislators if \
+                    (leg['name']['official_full'] == member['name']) \
+                    or ('bioguide' in leg['id'] and leg['id']['bioguide'] == member['bioguide']) \
+                    or ('thomas' in leg['id'] and leg['id']['thomas'] == member['thomas']) ):
+            self.lookup_legislator_properties(property,leg)
+
+    def lookup_by_lastname(self,property):
+        for leg in (leg for leg in self.legislators if fnmatch.fnmatch(leg['name']['last'],self.args.last_name)):
+            if self.args.debug: print(leg)
+            self.lookup_legislator_properties(property,leg)
+
+    def lookup_legislator_properties(self,property,legislator):
+        self.properties[property] = [term[property] for term in legislator['terms'] if property in term and len(term[property]) > 0]
+        for off in self.offices:
+            if self.args.debug: print(off)
+            if any(off['id'][db] == legislator['id'][db] for db in off['id'] if db in off['id'] and db in legislator['id']):
+                self.properties[property] += [ok[property] for ok in off['offices'] if property in ok and len(ok[property]) > 0]
+                break
+        print('Property \'{}\' for {}:'.format(property,legislator['name']['official_full'].encode('utf-8')))
+        print('\n'.join(self.properties[property]))
+
+    def database_load(self):
+        try:
+	    with self.database_access('legislators-current.yaml') as y:
+    	        self.legislators = yaml.load(y, Loader=yaml.CLoader)
+            with self.database_access('legislators-district-offices.yaml') as y:
+                self.offices = yaml.load(y, Loader=yaml.CLoader)
+            if self.args.committee is not None:
+                with self.database_access('committees-current.yaml') as y:
+                    self.committees = yaml.load(y, Loader=yaml.CLoader)
+                with self.database_access('committee-membership-current.yaml') as y:
+                    self.membership = yaml.load(y, Loader=yaml.CLoader)
+            else:
+                self.committees = None
+        except (BaseException,IOError) as e:
+            print(e)
+            raise Exception('Clone data from {} and copy it to {}.'.format(self.args.repo,self.data_path))
+
+    def database_access(self,filename):
+        if self.args.download:
+            if self.args.repo[-1] != '/': self.args.repo += '/'
+            url_base = urlparse.urljoin(urlparse.urlunparse(urlparse.urlparse(self.args.repo)._replace(netloc='raw.githubusercontent.com')),'master/')
+            # contextlib required for urlopen in with ... as for v < 3.3
+            res = contextlib.closing(urllib2.urlopen( urlparse.urljoin(url_base,filename) ))
+        else:
+            res = open(os.path.join(self.data_path,filename),'r')
+        return res        
+
+if __name__ == "__main__":
+    res = CongressLookup()

--- a/legislators-current.yaml
+++ b/legislators-current.yaml
@@ -2647,6 +2647,7 @@
     url: http://www.tomudall.senate.gov
     address: 110 Hart Senate Office Building Washington DC 20510
     phone: 202-224-6621
+    fax: 202-228-3261
     contact_form: http://www.tomudall.senate.gov/?p=contact
     office: 110 Hart Senate Office Building
     state_rank: senior
@@ -2776,7 +2777,7 @@
     url: http://gillibrand.senate.gov
     address: 478 RUSSELL SENATE OFFICE BUILDING WASHINGTON DC 20510
     phone: 202-224-4451
-    fax: 202-225-1168
+    fax: 202-228-0282
     contact_form: http://www.gillibrand.senate.gov/contact/
     office: 478 Russell Senate Office Building
   - type: sen
@@ -2880,6 +2881,7 @@
     url: http://www.coons.senate.gov
     address: 127A Russell Senate Office Building Washington DC 20510
     phone: 202-224-5042
+    fax: 202-228-3075
     contact_form: http://www.coons.senate.gov/contact/
     office: 127a Russell Senate Office Building
     state_rank: junior
@@ -3705,7 +3707,7 @@
     url: https://www.bennet.senate.gov
     address: 261 Russell Senate Office Building Washington DC 20510
     phone: 202-224-5852
-    fax: 202-228-5036
+    fax: 202-228-5097
     contact_form: http://www.bennet.senate.gov/contact/email
     office: 261 Russell Senate Office Building
     state_rank: senior
@@ -32628,6 +32630,7 @@
     office: 401 Cannon House Office Building
     address: 401 Cannon HOB; Washington DC 20515-2801
     phone: 202-225-5965
+    fax: 202-225-3119
     rss_url: http://titus.house.gov/rss.xml
     contact_form: https://titus.house.gov/contact/email-me
   - type: rep
@@ -34358,6 +34361,7 @@
     address: 317 Hart Senate Office Building Washington DC 20510
     office: 317 Hart Senate Office Building
     phone: 202-224-4543
+    fax: 202-228-2072
     state_rank: senior
     contact_form: http://www.warren.senate.gov/?p=email_senator#thisForm
     rss_url: http://www.warren.senate.gov/rss/?p=hot_topic
@@ -40156,6 +40160,7 @@
     office: 1530 Longworth House Office Building
     address: 1530 Longworth HOB; Washington DC 20515-2901
     phone: 202-225-5456
+    fax: 202-228-6362
     rss_url: http://shea-porter.house.gov/rss.xml
     contact_form: https://shea-porter.house.gov/contact/email-me
   - type: rep

--- a/legislators-district-offices.yaml
+++ b/legislators-district-offices.yaml
@@ -3408,7 +3408,7 @@
   - address: 500 W. Loockerman St.
     building: ''
     city: Dover
-    fax: ''
+    fax: 302-736-5609
     hours: ''
     phone: 302-736-5601
     state: DE
@@ -3419,7 +3419,7 @@
   - address: 1105 N. Market St.
     building: ''
     city: Wilmington
-    fax: ''
+    fax: 302-573-6351
     hours: ''
     phone: 302-573-6345
     state: DE
@@ -3684,7 +3684,7 @@
   - address: 300 E 8th
     building: ''
     city: Austin
-    fax: ''
+    fax: 512-916-5839
     hours: ''
     phone: 512-916-5834
     state: TX
@@ -3695,7 +3695,7 @@
   - address: 3626 N. Hall St.
     building: Lee Park Tower II
     city: Dallas
-    fax: ''
+    fax: 214-361-3518
     hours: ''
     phone: 214-599-8749
     state: TX
@@ -3706,7 +3706,7 @@
   - address: 808 Travis St.
     building: ''
     city: Houston
-    fax: ''
+    fax: 713-209-3459
     hours: ''
     phone: 713-718-3057
     state: TX
@@ -3728,7 +3728,7 @@
   - address: 9901 Ih-10w
     building: ''
     city: San Antonio
-    fax: ''
+    fax: 210-349-6753
     hours: ''
     phone: 210-340-2885
     state: TX
@@ -5418,7 +5418,7 @@
   - address: 515 W. 1st St.
     building: ''
     city: Duluth
-    fax: ''
+    fax: 218-722-4131
     hours: ''
     phone: 218-722-2390
     state: MN
@@ -5429,7 +5429,7 @@
   - address: 819 Center Ave.
     building: ''
     city: Moorhead
-    fax: ''
+    fax: 218-284-8721
     hours: ''
     phone: 218-284-8721
     state: MN
@@ -5440,7 +5440,7 @@
   - address: 1202-1/2 7th Street NW
     building: ''
     city: Rochester
-    fax: ''
+    fax: 507-288-2217
     hours: ''
     phone: 507-288-2003
     state: MN
@@ -5451,7 +5451,7 @@
   - address: 60 E. Plato Blvd.
     building: ''
     city: Saint Paul
-    fax: ''
+    fax: 651-221-1078
     hours: ''
     phone: 651-221-1016
     state: MN
@@ -10059,7 +10059,7 @@
   - address: 241 E. Main St.
     building: Federal Building
     city: Bowling Green
-    fax: ''
+    fax: 270-782-1884
     hours: ''
     phone: 270-781-1673
     state: KY
@@ -10070,7 +10070,7 @@
   - address: 1885 Dixie Hwy.
     building: ''
     city: Fort Wright
-    fax: ''
+    fax: 859-578-0488
     hours: ''
     phone: 859-578-0188
     state: KY
@@ -10081,7 +10081,7 @@
   - address: 771 Corporate Dr.
     building: ''
     city: Lexington
-    fax: ''
+    fax: 859-224-9673
     hours: ''
     phone: 859-224-8286
     state: KY
@@ -10092,7 +10092,7 @@
   - address: 300 S. Main St.
     building: ''
     city: London
-    fax: ''
+    fax: 606-864-2035
     hours: ''
     phone: 606-864-2026
     state: KY
@@ -10103,7 +10103,7 @@
   - address: 601 W. Broadway
     building: ''
     city: Louisville
-    fax: ''
+    fax: 502-582-5326
     hours: ''
     phone: 502-582-6304
     state: KY
@@ -10114,9 +10114,9 @@
   - address: 100 Fountain Ave.
     building: ''
     city: Paducah
-    fax: ''
+    fax: 270-443-3102
     hours: ''
-    phone: ''
+    phone: 270-442-4554
     state: KY
     suite: Suite 300
     zip: '42001'
@@ -12086,7 +12086,7 @@
   - address: 90 7th St.
     building: ''
     city: San Francisco
-    fax: ''
+    fax: 415-861-1670
     hours: M-F 9-5:30pm
     phone: 415-556-4862
     state: CA
@@ -16248,7 +16248,7 @@
   - address: 550 E. Charleston Blvd.
     building: ''
     city: Las Vegas
-    fax: ''
+    fax: 702-220-9841
     hours: M-F 8:30-5:30pm
     phone: 702-220-9823
     state: NV
@@ -16501,7 +16501,7 @@
   - address: 400 Gold Ave.
     building: ''
     city: Albuquerque
-    fax: ''
+    fax: 505-346-6720
     hours: ''
     phone: 505-346-6791
     state: NM
@@ -16523,7 +16523,7 @@
   - address: 201 N. Church St.
     building: ''
     city: Las Cruces
-    fax: ''
+    fax: 575-523-6589
     hours: ''
     phone: 575-526-5475
     state: NM
@@ -16545,7 +16545,7 @@
   - address: 120 S. Federal Pl.
     building: ''
     city: Santa Fe
-    fax: ''
+    fax: 505-988-6514
     hours: ''
     phone: 505-988-6511
     state: NM
@@ -17420,7 +17420,7 @@
   - address: 15 Sudbury St.
     building: 2400 JFK Federal Building
     city: Boston
-    fax: ''
+    fax: 617-723-7325
     hours: ''
     phone: 617-565-3170
     state: MA


### PR DESCRIPTION
This PR has an updated and corrected district and legislator data using independent cross reference, lookup script.

I'm posting the PR to this fork because there are questions on the parent of including the district data.

I used an independent data file to cross reference and check for errors:

```python
import csv,fnmatch,os,re,yaml

with open('congress_fax_data.csv','r') as c:
    cdata = [[w.replace('\xa0','') for w in line] for line in csv.reader(c)]

with open(os.path.expanduser('~/Source/github/essandess/congress-legislators/legislators-current.yaml'),'r') as y:
   ydata = yaml.load(y,Loader=yaml.CLoader)

check = dict()
for line in cdata:
    try:
        cfax = line[-1]
        names = line[0].split(' ')[1:]
        for leg in (leg for leg in ydata if fnmatch.fnmatch(leg['name']['last'],names[-1]) and fnmatch.fnmatch(leg['name']['first'],names[0])):
            yfax = [term['fax'] for term in leg['terms'] if 'fax' in term]
            if cfax not in yfax: check[line[0]] = line[1]
    except:
        pass
for name in check: print('{}: Check fax {}.'.format(name,check[name]))
```
