### PR TITLE
Add unique IDs for district offices

### DIFF
--- a/legislators-district-offices.yaml
+++ b/legislators-district-offices.yaml
@@ -14,6 +14,7 @@
     zip: '35055'
     latitude: 34.181059
     longitude: -86.840631
+    id: A000055-cullman
   - address: 600 Broad St.
     building: ''
     city: Gadsden
@@ -25,6 +26,7 @@
     zip: '35901'
     latitude: 34.01421000000001
     longitude: -86.006846
+    id: A000055-gadsden
   - address: 1710 Alabama Ave.
     building: ''
     city: Jasper
@@ -36,6 +38,7 @@
     zip: '35501'
     latitude: 33.834380
     longitude: -87.274935
+    id: A000055-jasper
   - address: 1011 George Wallace Blvd.
     building: ''
     city: Tuscumbia
@@ -47,6 +50,7 @@
     zip: '35674'
     latitude: 34.7412348
     longitude: -87.6794142
+    id: A000055-tuscumbia
 - id:
     bioguide: A000360
     govtrack: 300002
@@ -63,6 +67,7 @@
     zip: '37617'
     latitude: 36.473223
     longitude: -82.4092344
+    id: A000360-blountville
   - address: 900 Georgia Ave.
     building: Joel E. Soloman Federal Building
     city: Chattanooga
@@ -74,6 +79,7 @@
     zip: '37402'
     latitude: 35.0450875
     longitude: -85.3082146
+    id: A000360-chattanooga
   - address: 111 Murray Guard Dr.
     building: ''
     city: Jackson
@@ -85,6 +91,7 @@
     zip: '38305'
     latitude: 35.693264
     longitude: -88.852707
+    id: A000360-jackson
   - address: 800 Market St.
     building: Howard H. Baker, Jr., U.S. Courthouse
     city: Knoxville
@@ -96,6 +103,7 @@
     zip: '37902'
     latitude: 35.96172
     longitude: -83.91775799999999
+    id: A000360-knoxville
   - address: 167 N. Main St.
     building: Clifford Davis-Odell Horton Federal Building
     city: Memphis
@@ -107,6 +115,7 @@
     zip: '38103'
     latitude: 35.1497482
     longitude: -90.0517538
+    id: A000360-memphis
   - address: 3322 W. End Ave.
     building: ''
     city: Nashville
@@ -118,6 +127,7 @@
     zip: '37203'
     latitude: 36.1400262
     longitude: -86.8199101
+    id: A000360-nashville
 - id:
     bioguide: A000367
     govtrack: 412438
@@ -134,6 +144,7 @@
     zip: '49017'
     latitude: 42.3213842
     longitude: -85.1838246
+    id: A000367-battle_creek
   - address: 110 Michigan St.
     building: ''
     city: Grand Rapids
@@ -145,6 +156,7 @@
     zip: '49503'
     latitude: 42.96997460000001
     longitude: -85.67097419999999
+    id: A000367-grand_rapids
 - id:
     bioguide: A000369
     govtrack: 412500
@@ -161,6 +173,7 @@
     zip: '89801'
     latitude: 40.8355439
     longitude: -115.7586349
+    id: A000369-elko
   - address: 5310 Kietzke Ln.
     building: ''
     city: Reno
@@ -172,6 +185,7 @@
     zip: '89511'
     latitude: 39.4715058
     longitude: -119.791273
+    id: A000369-reno
 - id:
     bioguide: A000370
     govtrack: 412607
@@ -188,6 +202,7 @@
     zip: '28202'
     latitude: 35.215055
     longitude: -80.8452162
+    id: A000370-charlotte
 - id:
     bioguide: A000371
     govtrack: 412615
@@ -204,6 +219,7 @@
     zip: '92408'
     latitude: 34.068627
     longitude: -117.270925
+    id: A000371-san_bernardino
 - id:
     bioguide: A000372
     govtrack: 412625
@@ -220,6 +236,7 @@
     zip: '30909'
     latitude: 33.4875735
     longitude: -82.08466659999999
+    id: A000372-augusta
   - address: 100 S. Church St.
     building: ''
     city: Dublin
@@ -231,6 +248,7 @@
     zip: '31021'
     latitude: 32.5383565
     longitude: -82.9084154
+    id: A000372-dublin
   - address: 50 E. Main St.
     building: ''
     city: Statesboro
@@ -242,6 +260,7 @@
     zip: '30458'
     latitude: 32.4484951
     longitude: -81.781533
+    id: A000372-statesboro
   - address: 107 Old Airport Rd.
     building: ''
     city: Vidalia
@@ -253,6 +272,7 @@
     zip: '30475'
     latitude: 32.2046881
     longitude: -82.37632649999999
+    id: A000372-vidalia
 - id:
     bioguide: A000374
     govtrack: 412630
@@ -269,6 +289,7 @@
     zip: '71301'
     latitude: 31.27656
     longitude: -92.46964
+    id: A000374-alexandria
   - address: 426 Desiard St.
     building: ''
     city: Monroe
@@ -280,6 +301,7 @@
     zip: '71201'
     latitude: 32.5036093
     longitude: -92.1144236
+    id: A000374-monroe
 - id:
     bioguide: A000375
     govtrack: 412726
@@ -295,6 +317,7 @@
     zip: '79602'
     latitude: 32.4443053
     longitude: -99.73461449999999
+    id: A000375-abilene
   - address: 611 University Ave.
     building: ''
     city: Lubbock
@@ -306,6 +329,7 @@
     zip: '79401'
     latitude: 33.5885782
     longitude: -101.8702325
+    id: A000375-lubbock
 - id:
     bioguide: B000213
     govtrack: 400018
@@ -322,6 +346,7 @@
     zip: '76017'
     latitude: 32.6740058
     longitude: -97.20211789999999
+    id: B000213-arlington
   - address: 2106 W. Ennis Ave.
     building: ''
     city: Ennis
@@ -333,6 +358,7 @@
     zip: '75119'
     latitude: 32.3198509
     longitude: -96.6470243
+    id: B000213-ennis
 - id:
     bioguide: B000287
     govtrack: 400021
@@ -349,6 +375,7 @@
     zip: '90017'
     latitude: 34.0569399
     longitude: -118.2597013
+    id: B000287-los_angeles
 - id:
     bioguide: B000490
     govtrack: 400030
@@ -365,6 +392,7 @@
     zip: '31701'
     latitude: 31.5819859
     longitude: -84.15300719999999
+    id: B000490-albany
   - address: 18 Ninth St.
     building: ''
     city: Columbus
@@ -376,6 +404,7 @@
     zip: '31901'
     latitude: 32.4625755
     longitude: -84.9922596
+    id: B000490-columbus
   - address: 682 Cherry St.
     building: City Hall Annex
     city: Macon
@@ -387,6 +416,7 @@
     zip: '31201'
     latitude: 32.837156
     longitude: -83.63049699999999
+    id: B000490-macon
 - id:
     bioguide: B000574
     govtrack: 400033
@@ -403,6 +433,7 @@
     zip: '97232'
     latitude: 45.5293348
     longitude: -122.6555902
+    id: B000574-portland
 - id:
     bioguide: B000575
     govtrack: 400034
@@ -419,6 +450,7 @@
     zip: '63703'
     latitude: 37.30292850000001
     longitude: -89.55584789999999
+    id: B000575-cape_girardeau
   - address: 7700 Bonhomme
     building: ''
     city: Clayton
@@ -430,6 +462,7 @@
     zip: '63105'
     latitude: 38.647051
     longitude: -90.3351311
+    id: B000575-clayton
   - address: 1001 Cherry St.
     building: ''
     city: Columbia
@@ -441,6 +474,7 @@
     zip: '65201'
     latitude: 38.9507077
     longitude: -92.3262317
+    id: B000575-columbia
   - address: 1000 Walnut St.
     building: ''
     city: Kansas City
@@ -452,6 +486,7 @@
     zip: '64106'
     latitude: 39.1021449
     longitude: -94.5825038
+    id: B000575-kansas_city
   - address: 2740 E. Sunshine
     building: ''
     city: Springfield
@@ -463,6 +498,7 @@
     zip: '65804'
     latitude: 37.180415
     longitude: -93.240439
+    id: B000575-springfield
 - id:
     bioguide: B000755
     govtrack: 400046
@@ -479,6 +515,7 @@
     zip: '77304'
     latitude: 30.2844625
     longitude: -95.4613914
+    id: B000755-conroe
   - address: 1300 11th St.
     building: ''
     city: Huntsville
@@ -490,6 +527,7 @@
     zip: '77340'
     latitude: 30.7240052
     longitude: -95.5535049
+    id: B000755-huntsville
 - id:
     bioguide: B000944
     govtrack: 400050
@@ -506,6 +544,7 @@
     zip: '45202'
     latitude: 39.1007745
     longitude: -84.5120256
+    id: B000944-cincinnati
   - address: 801 W. Superior Ave.
     building: ''
     city: Cleveland
@@ -517,6 +556,7 @@
     zip: '44113'
     latitude: 41.4964399
     longitude: -81.6975439
+    id: B000944-cleveland
   - address: 200 N. High St.
     building: ''
     city: Columbus
@@ -528,6 +568,7 @@
     zip: '43215'
     latitude: 39.9666883
     longitude: -83.000974
+    id: B000944-columbus
   - address: 200 W. Erie Ave.
     building: ''
     city: Lorain
@@ -539,6 +580,7 @@
     zip: '44052'
     latitude: 41.4685695
     longitude: -82.1792684
+    id: B000944-lorain
 - id:
     bioguide: B001135
     govtrack: 400054
@@ -555,6 +597,7 @@
     zip: '28801'
     latitude: 35.594066
     longitude: -82.55792
+    id: B001135-asheville
   - address: 100 Coast Line St.
     building: ''
     city: Rocky Mount
@@ -566,6 +609,7 @@
     zip: '27804'
     latitude: 35.9379802
     longitude: -77.7977748
+    id: B001135-rocky_mount
   - address: 201 N. Front St.
     building: ''
     city: Wilmington
@@ -577,6 +621,7 @@
     zip: '28401'
     latitude: 34.2376985
     longitude: -77.9492582
+    id: B001135-wilmington
   - address: 2000 W. First St.
     building: ''
     city: Winston-Salem
@@ -588,6 +633,7 @@
     zip: '27104'
     latitude: 36.0960116
     longitude: -80.27480249999999
+    id: B001135-winston_salem
 - id:
     bioguide: B001227
     govtrack: 400047
@@ -604,6 +650,7 @@
     zip: '19013'
     latitude: 39.857906
     longitude: -75.3620646
+    id: B001227-chester
   - address: 2637 E. Clearfield St.
     building: ''
     city: Philadelphia
@@ -615,6 +662,7 @@
     zip: '19134'
     latitude: 39.9835935
     longitude: -75.1053451
+    id: B001227-philadelphia
   - address: 2630 Memphis St.
     building: ''
     city: Philadelphia
@@ -626,6 +674,7 @@
     zip: '19125'
     latitude: 39.98226349999999
     longitude: -75.11990449999999
+    id: B001227-philadelphia-1
   - address: 1909 S. Broad St.
     building: ''
     city: Philadelphia
@@ -637,6 +686,7 @@
     zip: '19148'
     latitude: 39.92649919999999
     longitude: -75.1689727
+    id: B001227-philadelphia-2
 - id:
     bioguide: B001230
     govtrack: 400013
@@ -653,6 +703,7 @@
     zip: '54701'
     latitude: 44.80949349999999
     longitude: -91.4995641
+    id: B001230-eau_claire
   - address: 1039 W. Mason
     building: ''
     city: Green Bay
@@ -664,6 +715,7 @@
     zip: '54303'
     latitude: 44.5151063
     longitude: -88.0413549
+    id: B001230-green_bay
   - address: 205 5th Avenue South
     building: ''
     city: La Crosse
@@ -675,6 +727,7 @@
     zip: '54601'
     latitude: 43.8109182
     longitude: -91.24976400000001
+    id: B001230-la_crosse
   - address: 30 W. Mifflin St.
     building: ''
     city: Madison
@@ -686,6 +739,7 @@
     zip: '53703'
     latitude: 43.07506559999999
     longitude: -89.38647139999999
+    id: B001230-madison
   - address: 633 W. Wisconsin Ave.
     building: ''
     city: Milwaukee
@@ -697,6 +751,7 @@
     zip: '53203'
     latitude: 43.0388214
     longitude: -87.9200848
+    id: B001230-milwaukee
   - address: 2100 Stewart Ave.
     building: ''
     city: Wausau
@@ -708,6 +763,7 @@
     zip: '54401'
     latitude: 44.9591474
     longitude: -89.6628755
+    id: B001230-wausau
 - id:
     bioguide: B001236
     govtrack: 400040
@@ -724,6 +780,7 @@
     zip: '71730'
     latitude: 33.2120448
     longitude: -92.664046
+    id: B001236-el_dorado
   - address: 1120 Garrison Ave.
     building: ''
     city: Fort Smith
@@ -735,6 +792,7 @@
     zip: '72901'
     latitude: 35.383512
     longitude: -94.42033099999999
+    id: B001236-fort_smith
   - address: 300 S. Church St.
     building: ''
     city: Jonesboro
@@ -746,6 +804,7 @@
     zip: '72401'
     latitude: 35.8404281
     longitude: -90.70368549999999
+    id: B001236-jonesboro
   - address: 1401 W. Capitol Ave.
     building: ''
     city: Little Rock
@@ -757,6 +816,7 @@
     zip: '72201'
     latitude: 34.7456872
     longitude: -92.2865752
+    id: B001236-little_rock
   - address: 213 W. Monroe
     building: ''
     city: Lowell
@@ -768,6 +828,7 @@
     zip: '72745'
     latitude: 36.2535183
     longitude: -94.1393049
+    id: B001236-lowell
   - address: 62 East
     building: ''
     city: Mountain Home
@@ -779,6 +840,7 @@
     zip: '72653'
     latitude: 36.3495507
     longitude: -92.37096679999999
+    id: B001236-mountain_home
   - address: 620 E. 22nd St.
     building: ''
     city: Stuttgart
@@ -790,6 +852,7 @@
     zip: '72160'
     latitude: 34.478784
     longitude: -91.54664090000001
+    id: B001236-stuttgart
 - id:
     bioguide: B001243
     govtrack: 400032
@@ -806,6 +869,7 @@
     zip: '37040'
     latitude: 36.5285913
     longitude: -87.35942089999999
+    id: B001243-clarksville
   - address: 305 Public Sq.
     building: ''
     city: Franklin
@@ -817,6 +881,7 @@
     zip: '37064'
     latitude: 35.9250525
     longitude: -86.86924189999999
+    id: B001243-franklin
 - id:
     bioguide: B001245
     govtrack: 400041
@@ -833,6 +898,7 @@
     zip: '96910'
     latitude: 13.4760084
     longitude: 144.7466326
+    id: B001245-hagåtña
 - id:
     bioguide: B001248
     govtrack: 400052
@@ -849,6 +915,7 @@
     zip: '75065'
     latitude: 33.1213325
     longitude: -97.0327015
+    id: B001248-lake_dallas
 - id:
     bioguide: B001250
     govtrack: 400029
@@ -865,6 +932,7 @@
     zip: '84302'
     latitude: 41.5106602
     longitude: -112.0154202
+    id: B001250-brigham_city
   - address: 324 25th St.
     building: Federal Building
     city: Ogden
@@ -876,6 +944,7 @@
     zip: '84401'
     latitude: 41.2206774
     longitude: -111.9726125
+    id: B001250-ogden
 - id:
     bioguide: B001251
     govtrack: 400616
@@ -892,6 +961,7 @@
     zip: '27701'
     latitude: 35.9963746
     longitude: -78.9082411
+    id: B001251-durham
   - address: 216 Nash St.
     building: ''
     city: Wilson
@@ -903,6 +973,7 @@
     zip: '27893'
     latitude: 35.728383
     longitude: -77.9131079
+    id: B001251-wilson
 - id:
     bioguide: B001257
     govtrack: 412250
@@ -919,6 +990,7 @@
     zip: '34654'
     latitude: 28.261156
     longitude: -82.674347
+    id: B001257-new_port_richey
   - address: 38500 US Highway 19 North
     building: ''
     city: Tarpon Springs
@@ -930,6 +1002,7 @@
     zip: '34689'
     latitude: 28.121418
     longitude: -82.74161199999999
+    id: B001257-tarpon_springs
 - id:
     bioguide: B001260
     govtrack: 412196
@@ -946,6 +1019,7 @@
     zip: '34205'
     latitude: 27.4945988
     longitude: -82.5724073
+    id: B001260-bradenton
   - address: 111 S. Orange Ave.
     building: ''
     city: Sarasota
@@ -957,6 +1031,7 @@
     zip: '34236'
     latitude: 27.3353999
     longitude: -82.5382987
+    id: B001260-sarasota
 - id:
     bioguide: B001261
     govtrack: 412251
@@ -973,6 +1048,7 @@
     zip: '82601'
     latitude: 42.8524124
     longitude: -106.3248373
+    id: B001261-casper
   - address: 2120 Capitol Ave.
     building: ''
     city: Cheyenne
@@ -984,6 +1060,7 @@
     zip: '82001'
     latitude: 41.1374591
     longitude: -104.8189674
+    id: B001261-cheyenne
   - address: 324 E. Washington Ave.
     building: ''
     city: Riverton
@@ -995,6 +1072,7 @@
     zip: '82501'
     latitude: 43.0238609
     longitude: -108.386731
+    id: B001261-riverton
   - address: 1575 Dewar Drive
     building: Commerce Bank
     city: Rock Springs
@@ -1006,6 +1084,7 @@
     zip: '82901'
     latitude: 41.5742346
     longitude: -109.2423116
+    id: B001261-rock_springs
   - address: 2 N. Main St.
     building: ''
     city: Sheridan
@@ -1017,6 +1096,7 @@
     zip: '82801'
     latitude: 44.7974506
     longitude: -106.9562525
+    id: B001261-sheridan
 - id:
     bioguide: B001267
     govtrack: 412330
@@ -1033,6 +1113,7 @@
     zip: '81101'
     latitude: 37.4685012
     longitude: -105.8659434
+    id: B001267-alamosa
   - address: 409 N. Tejon St.
     building: ''
     city: Colorado Springs
@@ -1044,6 +1125,7 @@
     zip: '80903'
     latitude: 38.8400247
     longitude: -104.8228748
+    id: B001267-colorado_springs
   - address: 1127 Sherman St.
     building: ''
     city: Denver
@@ -1055,6 +1137,7 @@
     zip: '80203'
     latitude: 39.734465
     longitude: -104.9852342
+    id: B001267-denver
   - address: 835 E. 2nd Ave.
     building: ''
     city: Durango
@@ -1066,6 +1149,7 @@
     zip: '81301'
     latitude: 37.2725939
     longitude: -107.8799634
+    id: B001267-durango
   - address: 1200 S. College Ave.
     building: ''
     city: Fort Collins
@@ -1077,6 +1161,7 @@
     zip: '80524'
     latitude: 40.5716714
     longitude: -105.0766516
+    id: B001267-fort_collins
   - address: 225 N. 5th St.
     building: ''
     city: Grand Junction
@@ -1088,6 +1173,7 @@
     zip: '81501'
     latitude: 39.0688046
     longitude: -108.5648398
+    id: B001267-grand_junction
   - address: 129 W. B St.
     building: ''
     city: Pueblo
@@ -1099,6 +1185,7 @@
     zip: '81003'
     latitude: 38.2795281
     longitude: -104.508253
+    id: B001267-pueblo
 - id:
     bioguide: B001269
     govtrack: 412469
@@ -1115,6 +1202,7 @@
     zip: '17013'
     latitude: 40.2036592
     longitude: -77.1889699
+    id: B001269-carlisle
   - address: 4813 Jonestown Rd.
     building: ''
     city: Harrisburg
@@ -1126,6 +1214,7 @@
     zip: '17109'
     latitude: 40.3042318
     longitude: -76.8076698
+    id: B001269-harrisburg
   - address: 1 S. Church St.
     building: ''
     city: Hazleton
@@ -1137,6 +1226,7 @@
     zip: '18201'
     latitude: 40.9545235
     longitude: -75.97691739999999
+    id: B001269-hazleton
   - address: 106 Arch St.
     building: ''
     city: Sunbury
@@ -1148,6 +1238,7 @@
     zip: '17801'
     latitude: 40.8643639
     longitude: -76.795568
+    id: B001269-sunbury
 - id:
     bioguide: B001270
     govtrack: 412404
@@ -1164,6 +1255,7 @@
     zip: '90010'
     latitude: 34.06264360000001
     longitude: -118.3381029
+    id: B001270-los_angeles
 - id:
     bioguide: B001273
     govtrack: 412478
@@ -1180,6 +1272,7 @@
     zip: '38501'
     latitude: 36.1618073
     longitude: -85.4996529
+    id: B001273-cookeville
   - address: 355 N. Belvedere Dr.
     building: ''
     city: Gallatin
@@ -1191,6 +1284,7 @@
     zip: '37066'
     latitude: 36.3784589
     longitude: -86.4789823
+    id: B001273-gallatin
 - id:
     bioguide: B001274
     govtrack: 412395
@@ -1207,6 +1301,7 @@
     zip: '35601'
     latitude: 34.6069984
     longitude: -86.9849204
+    id: B001274-decatur
   - address: 102 S. Court St.
     building: ''
     city: Florence
@@ -1218,6 +1313,7 @@
     zip: '35630'
     latitude: 34.8002305
     longitude: -87.6771285
+    id: B001274-florence
   - address: 2101 W. Clinton Ave.
     building: ''
     city: Huntsville
@@ -1229,6 +1325,7 @@
     zip: '35805'
     latitude: 34.7252133
     longitude: -86.5977423
+    id: B001274-huntsville
 - id:
     bioguide: B001275
     govtrack: 412427
@@ -1245,6 +1342,7 @@
     zip: '47708'
     latitude: 37.9722214
     longitude: -87.5705016
+    id: B001275-evansville
   - address: 610 Main St.
     building: First Floor Small Conference Room
     city: Jasper
@@ -1256,6 +1354,7 @@
     zip: '47547'
     latitude: 38.3919787
     longitude: -86.9304537
+    id: B001275-jasper
   - address: 901 Wabash Ave.
     building: ''
     city: Terre Haute
@@ -1267,6 +1366,7 @@
     zip: '47807'
     latitude: 39.466224
     longitude: -87.4042291
+    id: B001275-terre_haute
   - address: 1500 N. Chestnut St.
     building: ''
     city: Vincennes
@@ -1278,6 +1378,7 @@
     zip: '47591'
     latitude: 38.6911192
     longitude: -87.52073879999999
+    id: B001275-vincennes
 - id:
     bioguide: B001277
     govtrack: 412490
@@ -1294,6 +1395,7 @@
     zip: '06604'
     latitude: 41.1749972
     longitude: -73.1931954
+    id: B001277-bridgeport
   - address: 90 State House Sq.
     building: ''
     city: Hartford
@@ -1305,6 +1407,7 @@
     zip: '06103'
     latitude: 41.7665316
     longitude: -72.6719747
+    id: B001277-hartford
 - id:
     bioguide: B001278
     govtrack: 412501
@@ -1321,6 +1424,7 @@
     zip: '97005'
     latitude: 45.4900502
     longitude: -122.8078224
+    id: B001278-beaverton
 - id:
     bioguide: B001281
     govtrack: 412565
@@ -1337,6 +1441,7 @@
     zip: '43215'
     latitude: 39.9633834
     longitude: -82.9878075
+    id: B001281-columbus
 - id:
     bioguide: B001282
     govtrack: 412541
@@ -1353,6 +1458,7 @@
     zip: '40509'
     latitude: 38.0283634
     longitude: -84.4193762
+    id: B001282-lexington
 - id:
     bioguide: B001283
     govtrack: 412567
@@ -1369,6 +1475,7 @@
     zip: '74137'
     latitude: 36.0445807
     longitude: -95.95355529999999
+    id: B001283-tulsa
 - id:
     bioguide: B001284
     govtrack: 412539
@@ -1385,6 +1492,7 @@
     zip: '46016'
     latitude: 40.1083423
     longitude: -85.67763939999999
+    id: B001284-anderson
   - address: 11611 N. Meridian Street
     building: ''
     city: Carmel
@@ -1396,6 +1504,7 @@
     zip: '46032'
     latitude: 39.95690889999999
     longitude: -86.1563927
+    id: B001284-carmel
 - id:
     bioguide: B001285
     govtrack: 412516
@@ -1412,6 +1521,7 @@
     zip: '93036'
     latitude: 34.2283405
     longitude: -119.1745197
+    id: B001285-oxnard
   - address: 223 E. Thousand Oaks Blvd.
     building: ''
     city: Thousand Oaks
@@ -1423,6 +1533,7 @@
     zip: '91360'
     latitude: 34.1794905
     longitude: -118.8726791
+    id: B001285-thousand_oaks
 - id:
     bioguide: B001286
     govtrack: 412537
@@ -1439,6 +1550,7 @@
     zip: '61603'
     latitude: 40.7252144
     longitude: -89.59307679999999
+    id: B001286-peoria
   - address: 2401 4th Ave.
     building: ''
     city: Rock Island
@@ -1450,6 +1562,7 @@
     zip: '61201'
     latitude: 41.5089919
     longitude: -90.5662359
+    id: B001286-rock_island
   - address: 119 N. Church St.
     building: ''
     city: Rockford
@@ -1461,6 +1574,7 @@
     zip: '61101'
     latitude: 42.2720192
     longitude: -89.0952944
+    id: B001286-rockford
 - id:
     bioguide: B001287
     govtrack: 412512
@@ -1477,6 +1591,7 @@
     zip: '95826'
     latitude: 38.5553768
     longitude: -121.3738588
+    id: B001287-sacramento
 - id:
     bioguide: B001288
     govtrack: 412598
@@ -1493,6 +1608,7 @@
     zip: '08101'
     latitude: 39.9443128
     longitude: -75.1296174
+    id: B001288-camden
   - address: One Gateway Center
     building: ''
     city: Newark
@@ -1504,6 +1620,7 @@
     zip: '07102'
     latitude: 40.7344571
     longitude: -74.1657213
+    id: B001288-newark
 - id:
     bioguide: B001289
     govtrack: 412601
@@ -1520,6 +1637,7 @@
     zip: '36602'
     latitude: 30.693117
     longitude: -88.039675
+    id: B001289-mobile
   - address: 502 W. Lee Ave.
     building: ''
     city: Summerdale
@@ -1531,6 +1649,7 @@
     zip: '36580'
     latitude: 30.4834677
     longitude: -87.7041946
+    id: B001289-summerdale
 - id:
     bioguide: B001290
     govtrack: 412605
@@ -1547,6 +1666,7 @@
     zip: '23060'
     latitude: 37.6520841
     longitude: -77.58417519999999
+    id: B001290-glen_allen
   - address: 9104 Courthouse Rd.
     building: PO Box 99
     city: Spotsylvania
@@ -1558,6 +1678,7 @@
     zip: '22553'
     latitude: 38.2021276
     longitude: -77.58944939999999
+    id: B001290-spotsylvania
 - id:
     bioguide: B001291
     govtrack: 412655
@@ -1574,6 +1695,7 @@
     zip: '77536'
     latitude: 29.7089323
     longitude: -95.12126239999999
+    id: B001291-deer_park
   - address: 420 Green Ave.
     building: ''
     city: Orange
@@ -1585,6 +1707,7 @@
     zip: '77630'
     latitude: 30.093311
     longitude: -93.73304739999999
+    id: B001291-orange
   - address: 100 W. Bluff Dr.
     building: Tyler County Courthouse
     city: Woodville
@@ -1596,6 +1719,7 @@
     zip: '75979'
     latitude: 30.7753424
     longitude: -94.41539859999999
+    id: B001291-woodville
 - id:
     bioguide: B001292
     govtrack: 412657
@@ -1612,6 +1736,7 @@
     zip: '22312'
     latitude: 38.8086036
     longitude: -77.165008
+    id: B001292-alexandria
 - id:
     bioguide: B001293
     govtrack: 412635
@@ -1628,6 +1753,7 @@
     zip: '48116'
     latitude: 42.52504829999999
     longitude: -83.7760175
+    id: B001293-brighton
 - id:
     bioguide: B001294
     govtrack: 412627
@@ -1644,6 +1770,7 @@
     zip: '50613'
     latitude: 42.5338165
     longitude: -92.44589479999999
+    id: B001294-cedar_falls
   - address: 310 3rd Street SE
     building: ''
     city: Cedar Rapids
@@ -1655,6 +1782,7 @@
     zip: '50613'
     latitude: 41.9773904
     longitude: -91.6653664
+    id: B001294-cedar_rapids
   - address: 1050 Main St.
     building: ''
     city: Dubuque
@@ -1666,6 +1794,7 @@
     zip: '52001'
     latitude: 42.502919
     longitude: -90.6681282
+    id: B001294-dubuque
 - id:
     bioguide: B001295
     govtrack: 412629
@@ -1682,6 +1811,7 @@
     zip: '62002'
     latitude: 38.8906416
     longitude: -90.18395149999999
+    id: B001295-alton
   - address: 23 Public Sq.
     building: Public Square
     city: Belleville
@@ -1691,6 +1821,7 @@
     state: IL
     suite: Suite 404
     zip: '62220'
+    id: B001295-belleville
   - address: 300 E. Main St.
     building: Hunter Building
     city: Carbondale
@@ -1702,6 +1833,7 @@
     zip: '62901'
     latitude: 37.7277729
     longitude: -89.2134992
+    id: B001295-carbondale
   - address: 2000 Edison Ave.
     building: City Hall
     city: Granite City
@@ -1713,6 +1845,7 @@
     zip: '62040'
     latitude: 38.7015611
     longitude: -90.14887449999999
+    id: B001295-granite_city
   - address: 1100 Main St.
     building: Mt. Vernon City Hall
     city: Mt. Vernon
@@ -1724,6 +1857,7 @@
     zip: '62864'
     latitude: 38.317936
     longitude: -88.9049835
+    id: B001295-mt__vernon
 - id:
     bioguide: B001296
     govtrack: 412652
@@ -1740,6 +1874,7 @@
     zip: '19038'
     latitude: 40.100299
     longitude: -75.151156
+    id: B001296-glenside
   - address: 101 E. Main St.
     building: ''
     city: Norristown
@@ -1751,6 +1886,7 @@
     zip: '19401'
     latitude: 40.113802
     longitude: -75.3421376
+    id: B001296-norristown
   - address: 5675 N. Front St.
     building: ''
     city: Philadelphia
@@ -1762,6 +1898,7 @@
     zip: '19120'
     latitude: 40.0381812
     longitude: -75.1172342
+    id: B001296-philadelphia
   - address: 2375 Woodward St.
     building: The Towers
     city: Philadelphia
@@ -1773,6 +1910,7 @@
     zip: '19115'
     latitude: 40.0723585
     longitude: -75.03882949999999
+    id: B001296-philadelphia-1
 - id:
     bioguide: B001297
     govtrack: 412619
@@ -1789,6 +1927,7 @@
     zip: '80109'
     latitude: 39.4092665
     longitude: -104.8684125
+    id: B001297-castle_rock
   - address: 1023 39th Ave.
     building: ''
     city: Greeley
@@ -1800,6 +1939,7 @@
     zip: '80634'
     latitude: 40.4205693
     longitude: -104.7446355
+    id: B001297-greeley
 - id:
     bioguide: B001298
     govtrack: 412713
@@ -1815,6 +1955,7 @@
     zip: '68144'
     latitude: 41.23509809999999
     longitude: -96.1296555
+    id: B001298-omaha
 - id:
     bioguide: B001299
     govtrack: 412702
@@ -1830,6 +1971,7 @@
     zip: '46802'
     latitude: 41.0737372
     longitude: -85.14045349999999
+    id: B001299-fort_wayne
 - id:
     bioguide: B001300
     govtrack: 412687
@@ -1845,6 +1987,7 @@
     zip: '90731'
     latitude: 33.7398775
     longitude: -118.2839378
+    id: B001300-san_pedro
   - address: 8650 California Ave.
     building: ''
     city: South Gate
@@ -1856,6 +1999,7 @@
     zip: '90280'
     latitude: 33.9556898
     longitude: -118.2051037
+    id: B001300-south_gate
 - id:
     bioguide: B001302
     govtrack: 412683
@@ -1871,6 +2015,7 @@
     zip: '85209'
     latitude: 33.3712904
     longitude: -111.6870648
+    id: B001302-mesa
 - id:
     bioguide: B001303
     govtrack: 412689
@@ -1886,6 +2031,7 @@
     zip: '19801'
     latitude: 39.7473432
     longitude: -75.5471367
+    id: B001303-wilmington
 - id:
     bioguide: B001304
     govtrack: 412707
@@ -1901,6 +2047,7 @@
     zip: '20774'
     latitude: 38.9044752
     longitude: -76.8384674
+    id: B001304-upper_marlboro
 - id:
     bioguide: B001305
     govtrack: 412712
@@ -1916,6 +2063,7 @@
     zip: '27006'
     latitude: 36.0038879
     longitude: -80.4394348
+    id: B001305-advance
   - address: 116 Morlake Dr.
     building: ''
     city: Mooresville
@@ -1927,6 +2075,7 @@
     zip: '28117'
     latitude: 35.599466
     longitude: -80.863322
+    id: B001305-mooresville
 - id:
     bioguide: C000059
     govtrack: 400057
@@ -1943,6 +2092,7 @@
     zip: '92882'
     latitude: 33.8784386
     longitude: -117.5759232
+    id: C000059-corona
 - id:
     bioguide: C000127
     govtrack: 300018
@@ -1959,6 +2109,7 @@
     zip: '98201'
     latitude: 47.9781562
     longitude: -122.2076204
+    id: C000127-everett
   - address: 825 Jadwin Ave.
     building: ''
     city: Richland
@@ -1970,6 +2121,7 @@
     zip: '99352'
     latitude: 46.2775762
     longitude: -119.2760977
+    id: C000127-richland
   - address: 915 Second Ave.
     building: ''
     city: Seattle
@@ -1981,6 +2133,7 @@
     zip: '98174'
     latitude: 47.6045895
     longitude: -122.3354608
+    id: C000127-seattle
   - address: 920 W. Riverside Ave.
     building: ''
     city: Spokane
@@ -1992,6 +2145,7 @@
     zip: '99201'
     latitude: 47.6585992
     longitude: -117.4260094
+    id: C000127-spokane
   - address: 950 Pacific Ave.
     building: ''
     city: Tacoma
@@ -2003,6 +2157,7 @@
     zip: '98402'
     latitude: 47.2535757
     longitude: -122.4390697
+    id: C000127-tacoma
   - address: 1313 Officers Row.
     building: ''
     city: Vancouver
@@ -2014,6 +2169,7 @@
     zip: '98661'
     latitude: 45.628864
     longitude: -122.6641029
+    id: C000127-vancouver
 - id:
     bioguide: C000141
     govtrack: 400064
@@ -2030,6 +2186,7 @@
     zip: '21201'
     latitude: 39.2871649
     longitude: -76.6156372
+    id: C000141-baltimore
   - address: 10201 Martin Luther King Jr. Highway
     building: ''
     city: Bowie
@@ -2041,6 +2198,7 @@
     zip: '20720'
     latitude: 38.9550571
     longitude: -76.82809809999999
+    id: C000141-bowie
   - address: 13 Canal St.
     building: ''
     city: Cumberland
@@ -2052,6 +2210,7 @@
     zip: '21502'
     latitude: 39.6495579
     longitude: -78.76360249999999
+    id: C000141-cumberland
   - address: 451 Hungerford Dr.
     building: ''
     city: Rockville
@@ -2063,6 +2222,7 @@
     zip: '20850'
     latitude: 39.0895234
     longitude: -77.1511348
+    id: C000141-rockville
   - address: 212 W. Main St.
     building: Salisbury
     city: Salisbury
@@ -2074,6 +2234,7 @@
     zip: '21801'
     latitude: 38.3652837
     longitude: -75.6023764
+    id: C000141-salisbury
 - id:
     bioguide: C000174
     govtrack: 300019
@@ -2090,6 +2251,7 @@
     zip: '19904'
     latitude: 39.15666239999999
     longitude: -75.5311574
+    id: C000174-dover
   - address: 12 The Circle
     building: ''
     city: Georgetown
@@ -2101,6 +2263,7 @@
     zip: '19947'
     latitude: 38.6902745
     longitude: -75.3852914
+    id: C000174-georgetown
   - address: 301 N. Walnut St.
     building: ''
     city: Wilmington
@@ -2112,6 +2275,7 @@
     zip: 19801-3974
     latitude: 39.739183
     longitude: -75.5492666
+    id: C000174-wilmington
 - id:
     bioguide: C000266
     govtrack: 400071
@@ -2128,6 +2292,7 @@
     zip: '45202'
     latitude: 39.100836
     longitude: -84.513238
+    id: C000266-cincinnati
   - address: 11 S. Broadway
     building: ''
     city: Lebanon
@@ -2139,6 +2304,7 @@
     zip: '45036'
     latitude: 39.4341674
     longitude: -84.2086104
+    id: C000266-lebanon
 - id:
     bioguide: C000537
     govtrack: 400075
@@ -2155,6 +2321,7 @@
     zip: '29201'
     latitude: 34.0032484
     longitude: -81.03302830000001
+    id: C000537-columbia
   - address: 130 W. Main St.
     building: ''
     city: Kingstree
@@ -2166,6 +2333,7 @@
     zip: '29556'
     latitude: 33.6637604
     longitude: -79.8313355
+    id: C000537-kingstree
   - address: 176 Brooks Blvd.
     building: ''
     city: Santee
@@ -2177,6 +2345,7 @@
     zip: '29142'
     latitude: 33.4737478
     longitude: -80.4819747
+    id: C000537-santee
 - id:
     bioguide: C000567
     govtrack: 300023
@@ -2193,6 +2362,7 @@
     zip: '39501'
     latitude: 30.3692606
     longitude: -89.086237
+    id: C000567-gulfport
   - address: 190 E. Capitol St.
     building: ''
     city: Jackson
@@ -2204,6 +2374,7 @@
     zip: '39201'
     latitude: 32.3004566
     longitude: -90.186689
+    id: C000567-jackson
   - address: 911 East Jackson Avenue
     building: U.S. Federal Courthouse
     city: Oxford
@@ -2215,6 +2386,7 @@
     zip: '38655'
     latitude: 34.3671955
     longitude: -89.5213847
+    id: C000567-oxford
 - id:
     bioguide: C000714
     govtrack: 400080
@@ -2231,6 +2403,7 @@
     zip: '48226'
     latitude: 42.3303626
     longitude: -83.0496208
+    id: C000714-detroit
   - address: 33300 Warren Rd.
     building: ''
     city: Westland
@@ -2242,6 +2415,7 @@
     zip: '48185'
     latitude: 42.339678
     longitude: -83.3701998
+    id: C000714-westland
 - id:
     bioguide: C000754
     govtrack: 400081
@@ -2258,6 +2432,7 @@
     zip: '37219'
     latitude: 36.1623269
     longitude: -86.7817797
+    id: C000754-nashville
 - id:
     bioguide: C000880
     govtrack: 300030
@@ -2274,6 +2449,7 @@
     zip: '83702'
     latitude: 43.6086015
     longitude: -116.1956172
+    id: C000880-boise
   - address: 610 Hubbard Ave
     building: ''
     city: Coeur d'Alene
@@ -2285,6 +2461,7 @@
     zip: '83814'
     latitude: 47.6826921
     longitude: -116.7920799
+    id: C000880-coeur_d_alene
   - address: 410 Memorial Dr.
     building: ''
     city: Idaho Falls
@@ -2296,6 +2473,7 @@
     zip: '83402'
     latitude: 43.4936265
     longitude: -112.0425928
+    id: C000880-idaho_falls
   - address: 313 'd' St.
     building: ''
     city: Lewiston
@@ -2307,6 +2485,7 @@
     zip: '83501'
     latitude: 46.422158
     longitude: -117.028638
+    id: C000880-lewiston
   - address: 275 S. 5th Ave.
     building: ''
     city: Pocatello
@@ -2318,6 +2497,7 @@
     zip: '83201'
     latitude: 42.8649373
     longitude: -112.4428822
+    id: C000880-pocatello
   - address: 202 Falls Ave.
     building: ''
     city: Twin Falls
@@ -2329,6 +2509,7 @@
     zip: '83301'
     latitude: 42.5776169
     longitude: -114.47751
+    id: C000880-twin_falls
 - id:
     bioguide: C000984
     govtrack: 400090
@@ -2345,6 +2526,7 @@
     zip: '21201'
     latitude: 39.3030641
     longitude: -76.6191075
+    id: C000984-baltimore
   - address: 754 Frederick Rd.
     building: ''
     city: Catonsville
@@ -2356,6 +2538,7 @@
     zip: '21228'
     latitude: 39.2717668
     longitude: -76.73274339999999
+    id: C000984-catonsville
   - address: 8267 Main St.
     building: ''
     city: Ellicott
@@ -2367,6 +2550,7 @@
     zip: '21043'
     latitude: 39.2675157
     longitude: -76.7991703
+    id: C000984-ellicott
 - id:
     bioguide: C001035
     govtrack: 300025
@@ -2383,6 +2567,7 @@
     zip: '04330'
     latitude: 44.310824
     longitude: -69.783697
+    id: C001035-augusta
   - address: 202 Harlow St.
     building: ''
     city: Bangor
@@ -2394,6 +2579,7 @@
     zip: '04401'
     latitude: 44.8046399
     longitude: -68.7737891
+    id: C001035-bangor
   - address: 160 Main St.
     building: ''
     city: Biddeford
@@ -2405,6 +2591,7 @@
     zip: '04005'
     latitude: 43.493177
     longitude: -70.4548329
+    id: C001035-biddeford
   - address: 25 Sweden St.
     building: ''
     city: Caribou
@@ -2416,6 +2603,7 @@
     zip: '04736'
     latitude: 46.860458
     longitude: -68.013198
+    id: C001035-caribou
   - address: 55 Lisbon St.
     building: ''
     city: Lewiston
@@ -2427,6 +2615,7 @@
     zip: '04240'
     latitude: 44.097439
     longitude: -70.217972
+    id: C001035-lewiston
   - address: One Canal Plaza
     building: ''
     city: Portland
@@ -2438,6 +2627,7 @@
     zip: '04101'
     latitude: 43.6566885
     longitude: -70.2551294
+    id: C001035-portland
 - id:
     bioguide: C001037
     govtrack: 400063
@@ -2454,6 +2644,7 @@
     zip: '02141'
     latitude: 42.3678607
     longitude: -71.07730529999999
+    id: C001037-cambridge
   - address: 6 S. Main St.
     building: Stetson Hall
     city: Randolph
@@ -2465,6 +2656,7 @@
     zip: '02368'
     latitude: 42.1624223
     longitude: -71.0414069
+    id: C001037-randolph
   - address: 1234 Columbus Ave
     building: Roxbury Community College Campus Library
     city: Roxbury Crossing
@@ -2476,6 +2668,7 @@
     zip: '02120'
     latitude: 42.329238
     longitude: -71.095479
+    id: C001037-roxbury_crossing
 - id:
     bioguide: C001038
     govtrack: 400087
@@ -2492,6 +2685,7 @@
     zip: '10465'
     latitude: 40.83115069999999
     longitude: -73.83065909999999
+    id: C001038-bronx
   - address: 82-11 37th Ave.
     building: ''
     city: Queens
@@ -2503,6 +2697,7 @@
     zip: '11372'
     latitude: 40.7495961
     longitude: -73.88392929999999
+    id: C001038-queens
 - id:
     bioguide: C001047
     govtrack: 400061
@@ -2519,6 +2714,7 @@
     zip: '25801'
     latitude: 37.779625
     longitude: -81.188172
+    id: C001047-beckley
   - address: 500 Virgina Street East
     building: ''
     city: Charleston
@@ -2530,6 +2726,7 @@
     zip: '25301'
     latitude: 38.3511449
     longitude: -81.6380602
+    id: C001047-charleston
   - address: 300 Foxcroft Ave.
     building: ''
     city: Martinsburg
@@ -2541,6 +2738,7 @@
     zip: '25401'
     latitude: 39.4607489
     longitude: -77.986887
+    id: C001047-martinsburg
   - address: 48 Donley St.
     building: ''
     city: Morgantown
@@ -2552,6 +2750,7 @@
     zip: '26501'
     latitude: 39.6256581
     longitude: -79.96312549999999
+    id: C001047-morgantown
 - id:
     bioguide: C001048
     govtrack: 400089
@@ -2568,6 +2767,7 @@
     zip: '77024'
     latitude: 29.7788628
     longitude: -95.4831225
+    id: C001048-houston
 - id:
     bioguide: C001049
     govtrack: 400074
@@ -2584,6 +2784,7 @@
     zip: '63031'
     latitude: 38.7764554
     longitude: -90.33554869999999
+    id: C001049-florissant
   - address: 111 S. 10th St.
     building: ''
     city: St. Louis
@@ -2595,6 +2796,7 @@
     zip: '63102'
     latitude: 38.6254195
     longitude: -90.1970195
+    id: C001049-st__louis
   - address: 6830 Gravois
     building: ''
     city: St. Louis
@@ -2606,6 +2808,7 @@
     zip: '63116'
     latitude: 38.5704092
     longitude: -90.28441289999999
+    id: C001049-st__louis-1
 - id:
     bioguide: C001051
     govtrack: 400068
@@ -2622,6 +2825,7 @@
     zip: '78664'
     latitude: 30.5234565
     longitude: -97.688835
+    id: C001051-round_rock
   - address: 6544B S. General Bruce Drive
     building: ''
     city: Temple
@@ -2633,6 +2837,7 @@
     zip: '76502'
     latitude: 31.0718016
     longitude: -97.4233588
+    id: C001051-temple
 - id:
     bioguide: C001053
     govtrack: 400077
@@ -2649,6 +2854,7 @@
     zip: '73501'
     latitude: 34.6044481
     longitude: -98.3995211
+    id: C001053-lawton
   - address: 2424 Springer Dr.
     building: ''
     city: Norman
@@ -2660,6 +2866,7 @@
     zip: '73069'
     latitude: 35.2053158
     longitude: -97.47880409999999
+    id: C001053-norman
   - address: 100 E. 13th St.
     building: ''
     city: ada
@@ -2671,6 +2878,7 @@
     zip: '74820'
     latitude: 34.7723614
     longitude: -96.6790693
+    id: C001053-ada
 - id:
     bioguide: C001056
     govtrack: 300027
@@ -2687,6 +2895,7 @@
     zip: '78701'
     latitude: 30.2681008
     longitude: -97.7448471
+    id: C001056-austin
   - address: 5001 Spring Valley Rd.
     building: ''
     city: Dallas
@@ -2698,6 +2907,7 @@
     zip: '75244'
     latitude: 32.9400414
     longitude: -96.82359749999999
+    id: C001056-dallas
   - address: 222 E. Buren
     building: ''
     city: Harlingen
@@ -2709,6 +2919,7 @@
     zip: '78550'
     latitude: 26.1914148
     longitude: -97.69402009999999
+    id: C001056-harlingen
   - address: 5300 Memorial Dr.
     building: ''
     city: Houston
@@ -2720,6 +2931,7 @@
     zip: '77007'
     latitude: 29.7620629
     longitude: -95.41595319999999
+    id: C001056-houston
   - address: 1500 Broadway
     building: ''
     city: Lubbock
@@ -2731,6 +2943,7 @@
     zip: '79401'
     latitude: 33.5849492
     longitude: -101.8519083
+    id: C001056-lubbock
   - address: 600 Navarro
     building: ''
     city: San Antonio
@@ -2742,6 +2955,7 @@
     zip: '78205'
     latitude: 29.4267857
     longitude: -98.48957639999999
+    id: C001056-san_antonio
   - address: 100 E. Ferguson St.
     building: Regions Bank Building
     city: Tyler
@@ -2753,6 +2967,7 @@
     zip: '75702'
     latitude: 32.3522862
     longitude: -95.30028709999999
+    id: C001056-tyler
 - id:
     bioguide: C001059
     govtrack: 400618
@@ -2769,6 +2984,7 @@
     zip: '93721'
     latitude: 36.7345489
     longitude: -119.7858717
+    id: C001059-fresno
   - address: 2222 M St.
     building: ''
     city: Merced
@@ -2780,6 +2996,7 @@
     zip: '95340'
     latitude: 37.3070723
     longitude: -120.4812216
+    id: C001059-merced
 - id:
     bioguide: C001061
     govtrack: 400639
@@ -2796,6 +3013,7 @@
     zip: '64037'
     latitude: 39.0754557
     longitude: -93.7170832
+    id: C001061-higginsville
   - address: 211 W. Maple Ave.
     building: ''
     city: Independence
@@ -2807,6 +3025,7 @@
     zip: '64050'
     latitude: 39.0926561
     longitude: -94.41765029999999
+    id: C001061-independence
   - address: 101 W. 31 St.
     building: ''
     city: Kansas City
@@ -2818,6 +3037,7 @@
     zip: '64108'
     latitude: 39.070874
     longitude: -94.587124
+    id: C001061-kansas_city
 - id:
     bioguide: C001062
     govtrack: 400655
@@ -2834,6 +3054,7 @@
     zip: '76801'
     latitude: 31.7197496
     longitude: -98.98361140000002
+    id: C001062-brownwood
   - address: 132 Houston St.
     building: ''
     city: Granbury
@@ -2845,6 +3066,7 @@
     zip: '76048'
     latitude: 32.44305
     longitude: -97.78790599999999
+    id: C001062-granbury
   - address: 104 W. Sandstone
     building: ''
     city: Llano
@@ -2856,6 +3078,7 @@
     zip: '78643'
     latitude: 30.7492439
     longitude: -98.6764682
+    id: C001062-llano
   - address: 6 Desta Dr.
     building: ''
     city: Midland
@@ -2867,6 +3090,7 @@
     zip: '79705'
     latitude: 32.0303053
     longitude: -102.0856792
+    id: C001062-midland
   - address: 411 W. 8th St.
     building: City Hall
     city: Odessa
@@ -2878,6 +3102,7 @@
     zip: '79761'
     latitude: 31.848779
     longitude: -102.3748667
+    id: C001062-odessa
   - address: 33 E. Twohig
     building: ''
     city: San Angelo
@@ -2889,6 +3114,7 @@
     zip: '76903'
     latitude: 31.4614147
     longitude: -100.4355616
+    id: C001062-san_angelo
 - id:
     bioguide: C001063
     govtrack: 400657
@@ -2905,6 +3131,7 @@
     zip: '78041'
     latitude: 27.5423782
     longitude: -99.4887937
+    id: C001063-laredo
   - address: 117 E. Landry
     building: ''
     city: Mission
@@ -2916,6 +3143,7 @@
     zip: '78572'
     latitude: 26.2161009
     longitude: -98.32499899999999
+    id: C001063-mission
   - address: 100 N. F.M. 3167
     building: ''
     city: Rio Grande City
@@ -2927,6 +3155,7 @@
     zip: '78582'
     latitude: 26.3834188
     longitude: -98.85823049999999
+    id: C001063-rio_grande_city
   - address: 615 E. Houston St.
     building: ''
     city: San Antonio
@@ -2938,6 +3167,7 @@
     zip: '78205'
     latitude: 29.4270611
     longitude: -98.48622759999999
+    id: C001063-san_antonio
 - id:
     bioguide: C001066
     govtrack: 412195
@@ -2954,6 +3184,7 @@
     zip: '33607'
     latitude: 27.9771817
     longitude: -82.48520649999999
+    id: C001066-tampa
 - id:
     bioguide: C001067
     govtrack: 412221
@@ -2970,6 +3201,7 @@
     zip: '11226'
     latitude: 40.6536853
     longitude: -73.9516805
+    id: C001067-brooklyn
 - id:
     bioguide: C001068
     govtrack: 412236
@@ -2986,6 +3218,7 @@
     zip: '38103'
     latitude: 35.1497482
     longitude: -90.0517538
+    id: C001068-memphis
 - id:
     bioguide: C001069
     govtrack: 412193
@@ -3002,6 +3235,7 @@
     zip: '06082'
     latitude: 41.9904484
     longitude: -72.5723972
+    id: C001069-enfield
   - address: 55 Main St.
     building: ''
     city: Norwich
@@ -3013,6 +3247,7 @@
     zip: '06360'
     latitude: 41.524272
     longitude: -72.07896800000002
+    id: C001069-norwich
 - id:
     bioguide: C001070
     govtrack: 412246
@@ -3029,6 +3264,7 @@
     zip: '18101'
     latitude: 40.6010783
     longitude: -75.47499979999999
+    id: C001070-allentown
   - address: 817 E. Bishop St.
     building: ''
     city: Bellefonte
@@ -3040,6 +3276,7 @@
     zip: '16823'
     latitude: 40.9138418
     longitude: -77.7641528
+    id: C001070-bellefonte
   - address: 17 S. Park Row.
     building: ''
     city: Erie
@@ -3051,6 +3288,7 @@
     zip: '16501'
     latitude: 42.1289745
     longitude: -80.08406889999999
+    id: C001070-erie
   - address: 200 N. Third St.
     building: ''
     city: Harrisburg
@@ -3062,6 +3300,7 @@
     zip: '17101'
     latitude: 40.2619774
     longitude: -76.8829619
+    id: C001070-harrisburg
   - address: 2000 Market St.
     building: ''
     city: Philadelphia
@@ -3073,6 +3312,7 @@
     zip: '19103'
     latitude: 39.9532694
     longitude: -75.1736461
+    id: C001070-philadelphia
   - address: 310 Grant St.
     building: Grant Building
     city: Pittsburgh
@@ -3084,6 +3324,7 @@
     zip: '15219'
     latitude: 40.4376694
     longitude: -79.99749159999999
+    id: C001070-pittsburgh
   - address: 417 Lackawanna Ave.
     building: ''
     city: Scranton
@@ -3095,6 +3336,7 @@
     zip: '18503'
     latitude: 41.4073687
     longitude: -75.6654743
+    id: C001070-scranton
 - id:
     bioguide: C001071
     govtrack: 412248
@@ -3111,6 +3353,7 @@
     zip: '37402'
     latitude: 35.04543110000001
     longitude: -85.309912
+    id: C001071-chattanooga
   - address: 91 Stonebridge Blvd.
     building: ''
     city: Jackson
@@ -3122,6 +3365,7 @@
     zip: '38305'
     latitude: 35.675843
     longitude: -88.85342299999999
+    id: C001071-jackson
   - address: 1105 E. Jackson Blvd.
     building: ''
     city: Jonesborough
@@ -3133,6 +3377,7 @@
     zip: '37659'
     latitude: 36.3024064
     longitude: -82.45791890000001
+    id: C001071-jonesborough
   - address: 800 Market St.
     building: ''
     city: Knoxville
@@ -3144,6 +3389,7 @@
     zip: '37902'
     latitude: 35.96172
     longitude: -83.91775799999999
+    id: C001071-knoxville
   - address: 100 Peabody Pl.
     building: ''
     city: Memphis
@@ -3155,6 +3401,7 @@
     zip: '38103'
     latitude: 35.1412747
     longitude: -90.0540056
+    id: C001071-memphis
   - address: 3322 W. End Ave.
     building: ''
     city: Nashville
@@ -3166,6 +3413,7 @@
     zip: '37203'
     latitude: 36.1400262
     longitude: -86.8199101
+    id: C001071-nashville
 - id:
     bioguide: C001072
     govtrack: 412258
@@ -3182,6 +3430,7 @@
     zip: '46205'
     latitude: 39.8063243
     longitude: -86.1513962
+    id: C001072-indianapolis
 - id:
     bioguide: C001075
     govtrack: 412269
@@ -3198,6 +3447,7 @@
     zip: '71303'
     latitude: 31.2852075
     longitude: -92.47677350000001
+    id: C001075-alexandria
   - address: 5555 Hilton Ave.
     building: ''
     city: Baton Rouge
@@ -3209,6 +3459,7 @@
     zip: '70808'
     latitude: 30.423884
     longitude: -91.1325791
+    id: C001075-baton_rouge
   - address: 1 Lakeshore Dr.
     building: ''
     city: Lake Charles
@@ -3220,6 +3471,7 @@
     zip: '70629'
     latitude: 30.2305579
     longitude: -93.2196294
+    id: C001075-lake_charles
   - address: 101 France
     building: ''
     city: Lafayette
@@ -3231,6 +3483,7 @@
     zip: '70508'
     latitude: 30.1948666
     longitude: -92.014654
+    id: C001075-lafayette
   - address: 3421 N. Causeway Blvd.
     building: ''
     city: Metairie
@@ -3242,6 +3495,7 @@
     zip: '70002'
     latitude: 30.0112259
     longitude: -90.15417479999999
+    id: C001075-metairie
   - address: 1651 Louisville Ave.
     building: ''
     city: Monroe
@@ -3253,6 +3507,7 @@
     zip: '70201'
     latitude: 32.5175209
     longitude: -92.1087384
+    id: C001075-monroe
   - address: 6425 Youree Dr.
     building: ''
     city: Shreveport
@@ -3264,6 +3519,7 @@
     zip: '71105'
     latitude: 32.448457
     longitude: -93.71986679999999
+    id: C001075-shreveport
 - id:
     bioguide: C001076
     govtrack: 412270
@@ -3280,6 +3536,7 @@
     zip: '84601'
     latitude: 40.232986
     longitude: -111.6578512
+    id: C001076-provo
 - id:
     bioguide: C001077
     govtrack: 412271
@@ -3296,6 +3553,7 @@
     zip: '80014'
     latitude: 39.6574536
     longitude: -104.8354551
+    id: C001077-aurora
 - id:
     bioguide: C001078
     govtrack: 412272
@@ -3312,6 +3570,7 @@
     zip: '22003'
     latitude: 38.8338994
     longitude: -77.1967528
+    id: C001078-annandale
   - address: 2241-D Tacketts Mill Drive
     building: ''
     city: Woodbridge
@@ -3323,6 +3582,7 @@
     zip: '22192'
     latitude: 38.6752583
     longitude: -77.2815925
+    id: C001078-woodbridge
 - id:
     bioguide: C001080
     govtrack: 412379
@@ -3339,6 +3599,7 @@
     zip: '91711'
     latitude: 34.1079585
     longitude: -117.7212331
+    id: C001080-claremont
   - address: 527 S. Lake Ave.
     building: ''
     city: Pasadena
@@ -3350,6 +3611,7 @@
     zip: '91101'
     latitude: 34.1367185
     longitude: -118.1327226
+    id: C001080-pasadena
 - id:
     bioguide: C001084
     govtrack: 412470
@@ -3366,6 +3628,7 @@
     zip: '02860'
     latitude: 41.8610791
     longitude: -71.3986461
+    id: C001084-pawtucket
 - id:
     bioguide: C001087
     govtrack: 412400
@@ -3382,6 +3645,7 @@
     zip: '72023'
     latitude: 34.9730598
     longitude: -92.0167235
+    id: C001087-cabot
   - address: 2400 Highland Dr.
     building: ''
     city: Jonesboro
@@ -3393,6 +3657,7 @@
     zip: '72401'
     latitude: 35.8220219
     longitude: -90.6760171
+    id: C001087-jonesboro
   - address: 1001 Highway 62 E
     building: ''
     city: Mountain Home
@@ -3404,6 +3669,7 @@
     zip: '72653'
     latitude: 36.3499306
     longitude: -92.3707731
+    id: C001087-mountain_home
 - id:
     bioguide: C001088
     govtrack: 412390
@@ -3420,6 +3686,7 @@
     zip: '19904'
     latitude: 39.15666239999999
     longitude: -75.5311574
+    id: C001088-dover
   - address: 1105 N. Market St.
     building: ''
     city: Wilmington
@@ -3431,6 +3698,7 @@
     zip: 19801-1233
     latitude: 39.7473432
     longitude: -75.5471367
+    id: C001088-wilmington
 - id:
     bioguide: C001090
     govtrack: 412571
@@ -3447,6 +3715,7 @@
     zip: '18042'
     latitude: 40.6908081
     longitude: -75.2111997
+    id: C001090-easton
   - address: 121 Progress Ave.
     building: ''
     city: Pottsville
@@ -3458,6 +3727,7 @@
     zip: '17901'
     latitude: 40.6864175
     longitude: -76.1950516
+    id: C001090-pottsville
   - address: 226 Wyoming Ave.
     building: ''
     city: Scranton
@@ -3469,6 +3739,7 @@
     zip: '18503'
     latitude: 41.4093981
     longitude: -75.66439729999999
+    id: C001090-scranton
   - address: 20 N. Pennsylvania Ave.
     building: ''
     city: Wilkes-Barre
@@ -3480,6 +3751,7 @@
     zip: '18711'
     latitude: 41.2441677
     longitude: -75.87917089999999
+    id: C001090-wilkes_barre
 - id:
     bioguide: C001091
     govtrack: 412576
@@ -3496,6 +3768,7 @@
     zip: '78206'
     latitude: 29.4175269
     longitude: -98.4846276
+    id: C001091-san_antonio
 - id:
     bioguide: C001092
     govtrack: 412563
@@ -3512,6 +3785,7 @@
     zip: '14454'
     latitude: 42.794794
     longitude: -77.817404
+    id: C001092-geneseo
   - address: 2813 Wehrle Dr.
     building: ''
     city: Williamsville
@@ -3523,6 +3797,7 @@
     zip: '14221'
     latitude: 42.9552643
     longitude: -78.6780537
+    id: C001092-williamsville
 - id:
     bioguide: C001093
     govtrack: 412531
@@ -3539,6 +3814,7 @@
     zip: '30501'
     latitude: 34.299434
     longitude: -83.8282158
+    id: C001093-gainesville
 - id:
     bioguide: C001094
     govtrack: 412513
@@ -3555,6 +3831,7 @@
     zip: '92307'
     latitude: 34.5243014
     longitude: -117.2144307
+    id: C001094-apple_valley
   - address: 34282 Yucaipa Boulevard
     building: ''
     city: Yucaipa
@@ -3566,6 +3843,7 @@
     zip: '92399'
     latitude: 34.0344717
     longitude: -117.0567352
+    id: C001094-yucaipa
 - id:
     bioguide: C001095
     govtrack: 412508
@@ -3582,6 +3860,7 @@
     zip: '71730'
     latitude: 33.2120448
     longitude: -92.664046
+    id: C001095-el_dorado
   - address: 300 S. Church
     building: ''
     city: Jonesboro
@@ -3593,6 +3872,7 @@
     zip: '72401'
     latitude: 35.8404281
     longitude: -90.70368549999999
+    id: C001095-jonesboro
   - address: 1401 W. Capitol Ave.
     building: ''
     city: Little Rock
@@ -3604,6 +3884,7 @@
     zip: '72201'
     latitude: 34.7456872
     longitude: -92.2865752
+    id: C001095-little_rock
   - address: 1108 S. Old Missouri Rd.
     building: ''
     city: Springdale
@@ -3615,6 +3896,7 @@
     zip: '72764'
     latitude: 36.17457100000001
     longitude: -94.1176151
+    id: C001095-springdale
 - id:
     bioguide: C001096
     govtrack: 412555
@@ -3631,6 +3913,7 @@
     zip: '58501'
     latitude: 46.80901129999999
     longitude: -100.7882597
+    id: C001096-bismarck
   - address: 3217 Fiechtner Dr.
     building: ''
     city: Fargo
@@ -3642,6 +3925,7 @@
     zip: '58103'
     latitude: 46.8653775
     longitude: -96.83148949999999
+    id: C001096-fargo
   - address: 4200 James Ray Dr.
     building: ''
     city: Grand Forks
@@ -3653,6 +3937,7 @@
     zip: '58202'
     latitude: 47.921087
     longitude: -97.090537
+    id: C001096-grand_forks
   - address: 315 Main St.
     building: ''
     city: Minot
@@ -3664,6 +3949,7 @@
     zip: '58701'
     latitude: 48.23281009999999
     longitude: -101.2926299
+    id: C001096-minot
 - id:
     bioguide: C001097
     govtrack: 412517
@@ -3680,6 +3966,7 @@
     zip: '91402'
     latitude: 34.2449325
     longitude: -118.4495976
+    id: C001097-panorama_city
 - id:
     bioguide: C001098
     govtrack: 412573
@@ -3696,6 +3983,7 @@
     zip: '78701'
     latitude: 30.269401
     longitude: -97.7390867
+    id: C001098-austin
   - address: 3626 N. Hall St.
     building: Lee Park Tower II
     city: Dallas
@@ -3707,6 +3995,7 @@
     zip: '75219'
     latitude: 32.8092691
     longitude: -96.8059281
+    id: C001098-dallas
   - address: 808 Travis St.
     building: ''
     city: Houston
@@ -3718,6 +4007,7 @@
     zip: '77002'
     latitude: 29.758844
     longitude: -95.3650242
+    id: C001098-houston
   - address: 200 S. 10th St.
     building: ''
     city: McAllen
@@ -3729,6 +4019,7 @@
     zip: '78501'
     latitude: 26.2019273
     longitude: -98.2313667
+    id: C001098-mcallen
   - address: 9901 Ih-10w
     building: ''
     city: San Antonio
@@ -3740,6 +4031,7 @@
     zip: '78230'
     latitude: 29.533858
     longitude: -98.5619881
+    id: C001098-san_antonio
   - address: 305 S. Broadway
     building: ''
     city: Tyler
@@ -3751,6 +4043,7 @@
     zip: '75702'
     latitude: 32.3480097
     longitude: -95.3009807
+    id: C001098-tyler
 - id:
     bioguide: C001101
     govtrack: 412600
@@ -3767,6 +4060,7 @@
     zip: '02138'
     latitude: 42.390572
     longitude: -71.151338
+    id: C001101-cambridge
   - address: 116 Concord St.
     building: ''
     city: Framingham
@@ -3778,6 +4072,7 @@
     zip: '01702'
     latitude: 42.2787415
     longitude: -71.41700349999999
+    id: C001101-framingham
 - id:
     bioguide: C001103
     govtrack: 412622
@@ -3794,6 +4089,7 @@
     zip: '31520'
     latitude: 31.149693
     longitude: -81.49532
+    id: C001103-brunswick
   - address: 6602 Abercorn St.
     building: ''
     city: Savannah
@@ -3805,6 +4101,7 @@
     zip: '31405'
     latitude: 32.017594
     longitude: -81.11040299999999
+    id: C001103-savannah
 - id:
     bioguide: C001105
     govtrack: 412658
@@ -3821,6 +4118,7 @@
     zip: '20164'
     latitude: 39.0191653
     longitude: -77.37826129999999
+    id: C001105-sterling
   - address: 117 E. Piccadilly St.
     building: ''
     city: Winchester
@@ -3832,6 +4130,7 @@
     zip: '22601'
     latitude: 39.185574
     longitude: -78.1625238
+    id: C001105-winchester
 - id:
     bioguide: C001106
     govtrack: 412651
@@ -3848,6 +4147,7 @@
     zip: '19382'
     latitude: 39.9594999
     longitude: -75.6049795
+    id: C001106-west_chester
   - address: 840 N. Park Rd.
     building: ''
     city: Wyomissing
@@ -3859,6 +4159,7 @@
     zip: '19610'
     latitude: 40.34662770000001
     longitude: -75.9595672
+    id: C001106-wyomissing
 - id:
     bioguide: C001107
     govtrack: 412621
@@ -3875,6 +4176,7 @@
     zip: '33034'
     latitude: 25.4483513
     longitude: -80.4827158
+    id: C001107-florida_city
   - address: 1100 Simonton St.
     building: ''
     city: Key West
@@ -3886,6 +4188,7 @@
     zip: '33040'
     latitude: 24.5505584
     longitude: -81.7973549
+    id: C001107-key_west
   - address: 12851 SW 42nd Street
     building: ''
     city: Miami
@@ -3897,6 +4200,7 @@
     zip: '33175'
     latitude: 25.7298536
     longitude: -80.4026651
+    id: C001107-miami
 - id:
     bioguide: C001108
     govtrack: 412676
@@ -3912,6 +4216,7 @@
     zip: '42003'
     latitude: 37.0851283
     longitude: -88.595174
+    id: C001108-paducah
   - address: 200 N. Main St.
     building: ''
     city: Tompkinsville
@@ -3923,6 +4228,7 @@
     zip: '42167'
     latitude: 36.7006713
     longitude: -85.6929017
+    id: C001108-tompkinsville
 - id:
     bioguide: C001109
     govtrack: 412732
@@ -3938,6 +4244,7 @@
     zip: '82602'
     latitude: 42.8524124
     longitude: -106.3248373
+    id: C001109-casper
   - address: 2120 Capitol Ave.
     building: ''
     city: Cheyenne
@@ -3949,6 +4256,7 @@
     zip: '82001'
     latitude: 41.1374591
     longitude: -104.8189674
+    id: C001109-cheyenne
   - address: 45 E. Loucks St.
     building: ''
     city: Sheridan
@@ -3960,6 +4268,7 @@
     zip: '82801'
     latitude: 44.7974845
     longitude: -106.9548869
+    id: C001109-sheridan
 - id:
     bioguide: C001112
     govtrack: 412686
@@ -3975,6 +4284,7 @@
     zip: '93401'
     latitude: 35.2838648
     longitude: -120.6538213
+    id: C001112-san_luis_obispo
   - address: 360 S. Hope Ave.
     building: ''
     city: Santa Barbara
@@ -3986,6 +4296,7 @@
     zip: '93105'
     latitude: 34.434901
     longitude: -119.746862
+    id: C001112-santa_barbara
 - id:
     bioguide: D000096
     govtrack: 400093
@@ -4002,6 +4313,7 @@
     zip: '60612'
     latitude: 41.88125790000001
     longitude: -87.69572930000001
+    id: D000096-chicago
 - id:
     bioguide: D000191
     govtrack: 400100
@@ -4018,6 +4330,7 @@
     zip: '97420'
     latitude: 43.367748
     longitude: -124.213429
+    id: D000191-coos_bay
   - address: 405 E. 8th Ave.
     building: ''
     city: Eugene
@@ -4029,6 +4342,7 @@
     zip: '97401'
     latitude: 44.0516985
     longitude: -123.0857882
+    id: D000191-eugene
   - address: 612 SE. Jackson St.
     building: ''
     city: Roseburg
@@ -4040,6 +4354,7 @@
     zip: '97470'
     latitude: 43.2087597
     longitude: -123.3445182
+    id: D000191-roseburg
 - id:
     bioguide: D000197
     govtrack: 400101
@@ -4056,6 +4371,7 @@
     zip: '80203'
     latitude: 39.7260392
     longitude: -104.9832743
+    id: D000197-denver
 - id:
     bioguide: D000216
     govtrack: 400103
@@ -4072,6 +4388,7 @@
     zip: '06510'
     latitude: 41.3080224
     longitude: -72.92267679999999
+    id: D000216-new_haven
 - id:
     bioguide: D000399
     govtrack: 400111
@@ -4088,6 +4405,7 @@
     zip: '78701'
     latitude: 30.269401
     longitude: -97.7390867
+    id: D000399-austin
   - address: 217 W. Travis St.
     building: ''
     city: San Antonio
@@ -4099,6 +4417,7 @@
     zip: '78205'
     latitude: 29.427604
     longitude: -98.4951151
+    id: D000399-san_antonio
 - id:
     bioguide: D000482
     govtrack: 400114
@@ -4116,6 +4435,7 @@
     zip: '15108'
     latitude: 40.5150506
     longitude: -80.157861
+    id: D000482-coraopolis
   - address: 627 Lysle Blvd.
     building: ''
     city: McKeesport
@@ -4127,6 +4447,7 @@
     zip: '15132'
     latitude: 40.352477
     longitude: -79.858547
+    id: D000482-mckeesport
   - address: 11 Duff Rd.
     building: ''
     city: Penn Hills
@@ -4138,6 +4459,7 @@
     zip: '15235'
     latitude: 40.4644937
     longitude: -79.8281138
+    id: D000482-penn_hills
   - address: 2637 E. Carson St.
     building: ''
     city: Pittsburgh
@@ -4149,6 +4471,7 @@
     zip: '15203'
     latitude: 40.4273525
     longitude: -79.9675163
+    id: D000482-pittsburgh
 - id:
     bioguide: D000533
     govtrack: 400116
@@ -4165,6 +4488,7 @@
     zip: '37902'
     latitude: 35.96172
     longitude: -83.91775799999999
+    id: D000533-knoxville
   - address: 331 Court St.
     building: ''
     city: Maryville
@@ -4176,6 +4500,7 @@
     zip: '37804'
     latitude: 35.7548786
     longitude: -83.9690043
+    id: D000533-maryville
 - id:
     bioguide: D000563
     govtrack: 300038
@@ -4192,6 +4517,7 @@
     zip: '62901'
     latitude: 37.7233822
     longitude: -89.21730319999999
+    id: D000563-carbondale
   - address: 230 S. Dearborn St.
     building: ''
     city: Chicago
@@ -4203,6 +4529,7 @@
     zip: '60604'
     latitude: 41.8784454
     longitude: -87.63
+    id: D000563-chicago
   - address: 1504 Third Ave.
     building: ''
     city: Rock Island
@@ -4214,6 +4541,7 @@
     zip: '61201'
     latitude: 41.5090535
     longitude: -90.5782533
+    id: D000563-rock_island
   - address: 525 S. 8th St.
     building: ''
     city: Springfield
@@ -4225,6 +4553,7 @@
     zip: '62703'
     latitude: 39.7965137
     longitude: -89.6451404
+    id: D000563-springfield
 - id:
     bioguide: D000598
     govtrack: 400097
@@ -4241,6 +4570,7 @@
     zip: '92116'
     latitude: 32.7631233
     longitude: -117.1348898
+    id: D000598-san_diego
 - id:
     bioguide: D000600
     govtrack: 400108
@@ -4257,6 +4587,7 @@
     zip: '33166'
     latitude: 25.8109245
     longitude: -80.3361915
+    id: D000600-doral
   - address: 4715 Golden Gate Pky.
     building: ''
     city: Naples
@@ -4268,6 +4599,7 @@
     zip: '34116'
     latitude: 26.1833954
     longitude: -81.70380209999999
+    id: D000600-naples
 - id:
     bioguide: D000604
     govtrack: 400648
@@ -4284,6 +4616,7 @@
     zip: '18103'
     latitude: 40.5733973
     longitude: -75.535032
+    id: D000604-allentown
   - address: 342 W. Main St.
     building: ''
     city: Annville
@@ -4295,6 +4628,7 @@
     zip: '17003'
     latitude: 40.32787
     longitude: -76.521464
+    id: D000604-annville
   - address: 61 N. 3rd St.
     building: ''
     city: Hamburg
@@ -4306,6 +4640,7 @@
     zip: '19526'
     latitude: 40.556407
     longitude: -75.9840798
+    id: D000604-hamburg
   - address: 250 W. Chocolate Ave.
     building: ''
     city: Hershey
@@ -4317,6 +4652,7 @@
     zip: '17033'
     latitude: 40.2832262
     longitude: -76.6556063
+    id: D000604-hershey
 - id:
     bioguide: D000607
     govtrack: 412205
@@ -4333,6 +4669,7 @@
     zip: '47708'
     latitude: 37.9732451
     longitude: -87.5720272
+    id: D000607-evansville
   - address: 203 E. Berry St.
     building: ''
     city: Fort Wayne
@@ -4344,6 +4681,7 @@
     zip: '46802'
     latitude: 41.0798997
     longitude: -85.1378306
+    id: D000607-fort_wayne
   - address: 5400 Federal Plz.
     building: ''
     city: Hammond
@@ -4355,6 +4693,7 @@
     zip: '46320'
     latitude: 41.6153792
     longitude: -87.52120889999999
+    id: D000607-hammond
   - address: 115 N. Pennsylvania St.
     building: ''
     city: Indianapolis
@@ -4366,6 +4705,7 @@
     zip: '46204'
     latitude: 39.7689854
     longitude: -86.1559046
+    id: D000607-indianapolis
   - address: 702 North Shore Drive
     building: ''
     city: Jeffersonville
@@ -4377,6 +4717,7 @@
     zip: '47130'
     latitude: 38.271605
     longitude: -85.74881719999999
+    id: D000607-jeffersonville
   - address: 205 W. Colfax Ave.
     building: ''
     city: South Bend
@@ -4388,6 +4729,7 @@
     zip: '46601'
     latitude: 41.6778965
     longitude: -86.25246949999999
+    id: D000607-south_bend
 - id:
     bioguide: D000610
     govtrack: 412385
@@ -4404,6 +4746,7 @@
     zip: '33434'
     latitude: 26.365483
     longitude: -80.1673666
+    id: D000610-boca_raton
   - address: 1300 Coral Springs Dr.
     building: ''
     city: Coral Springs
@@ -4415,6 +4758,7 @@
     zip: '33071'
     latitude: 26.2459273
     longitude: -80.2697548
+    id: D000610-coral_springs
   - address: 5790 Margate Blvd.
     building: ''
     city: Margate
@@ -4426,6 +4770,7 @@
     zip: '33063'
     latitude: 26.2420954
     longitude: -80.2050177
+    id: D000610-margate
 - id:
     bioguide: D000612
     govtrack: 412403
@@ -4442,6 +4787,7 @@
     zip: '95356'
     latitude: 37.70717459999999
     longitude: -121.0778461
+    id: D000612-modesto
 - id:
     bioguide: D000614
     govtrack: 412488
@@ -4458,6 +4804,7 @@
     zip: '54843'
     latitude: 46.0039436
     longitude: -91.4901222
+    id: D000614-hayward
   - address: 502 2nd St.
     building: ''
     city: Hudson
@@ -4469,6 +4816,7 @@
     zip: '54016'
     latitude: 44.9750352
     longitude: -92.7566503
+    id: D000614-hudson
   - address: 208 Grand Ave.
     building: ''
     city: Wausau
@@ -4480,6 +4828,7 @@
     zip: '54403'
     latitude: 44.955171
     longitude: -89.624724
+    id: D000614-wausau
 - id:
     bioguide: D000615
     govtrack: 412472
@@ -4496,6 +4845,7 @@
     zip: '29625'
     latitude: 34.5490603
     longitude: -82.6746057
+    id: D000615-anderson
   - address: 200 Courthouse Public Square
     building: ''
     city: Laurens
@@ -4507,6 +4857,7 @@
     zip: '29360'
     latitude: 34.4993065
     longitude: -82.0144844
+    id: D000615-laurens
 - id:
     bioguide: D000616
     govtrack: 412477
@@ -4523,6 +4874,7 @@
     zip: '37311'
     latitude: 35.160062
     longitude: -84.88402219999999
+    id: D000616-cleveland
   - address: 711 N. Garden St.
     building: ''
     city: Columbia
@@ -4534,6 +4886,7 @@
     zip: '38401'
     latitude: 35.61587
     longitude: -87.035826
+    id: D000616-columbia
   - address: 305 W. Main St.
     building: ''
     city: Murfreesboro
@@ -4545,6 +4898,7 @@
     zip: '37130'
     latitude: 35.8461158
     longitude: -86.39409649999999
+    id: D000616-murfreesboro
   - address: 200 S. Jefferson St.
     building: Federal Building
     city: Winchester
@@ -4556,6 +4910,7 @@
     zip: '37398'
     latitude: 35.1850086
     longitude: -86.1112284
+    id: D000616-winchester
 - id:
     bioguide: D000617
     govtrack: 412505
@@ -4572,6 +4927,7 @@
     zip: '98021'
     latitude: 47.7965458
     longitude: -122.2097757
+    id: D000617-bothell
   - address: 204 W. Montgomery St.
     building: ''
     city: Mount Vernon
@@ -4583,6 +4939,7 @@
     zip: '98273'
     latitude: 48.41949899999999
     longitude: -122.3357879
+    id: D000617-mount_vernon
 - id:
     bioguide: D000618
     govtrack: 412549
@@ -4599,6 +4956,7 @@
     zip: '59101'
     latitude: 45.7810512
     longitude: -108.5125313
+    id: D000618-billings
   - address: 13 S. Willson Ave.
     building: ''
     city: Bozeman
@@ -4610,6 +4968,7 @@
     zip: '59718'
     latitude: 45.6788798
     longitude: -111.0390251
+    id: D000618-bozeman
   - address: 104 4th Street North
     building: ''
     city: Great Falls
@@ -4621,6 +4980,7 @@
     zip: '59401'
     latitude: 47.5067244
     longitude: -111.3009733
+    id: D000618-great_falls
   - address: 310 N Ctr.
     building: ''
     city: Hardin
@@ -4632,6 +4992,7 @@
     zip: '59034'
     latitude: 45.731817
     longitude: -107.606432
+    id: D000618-hardin
   - address: 30 W. 14th St.
     building: ''
     city: Helena
@@ -4643,6 +5004,7 @@
     zip: '59601'
     latitude: 46.596642
     longitude: -112.036443
+    id: D000618-helena
   - address: 40 2nd St East
     building: KM Building
     city: Kalispell
@@ -4654,6 +5016,7 @@
     zip: '59901'
     latitude: 48.19663569999999
     longitude: -114.3118812
+    id: D000618-kalispell
   - address: 218 E. Front St.
     building: ''
     city: Missoula
@@ -4665,6 +5028,7 @@
     zip: '59802'
     latitude: 46.8699041
     longitude: -113.9930208
+    id: D000618-missoula
   - address: 609 S. Central Ave.
     building: (Central Plaza Building)
     city: Sidney
@@ -4676,6 +5040,7 @@
     zip: '59270'
     latitude: 47.7106368
     longitude: -104.1606344
+    id: D000618-sidney
 - id:
     bioguide: D000619
     govtrack: 412536
@@ -4692,6 +5057,7 @@
     zip: '61280'
     latitude: 40.090932
     longitude: -88.25012439999999
+    id: D000619-champaign
   - address: 243 S. Water St.
     building: ''
     city: Decatur
@@ -4703,6 +5069,7 @@
     zip: '62523'
     latitude: 39.8396384
     longitude: -88.954852
+    id: D000619-decatur
   - address: 15 Professional Park Dr.
     building: ''
     city: Maryville
@@ -4714,6 +5081,7 @@
     zip: '62062'
     latitude: 38.737077
     longitude: -89.95489859999999
+    id: D000619-maryville
   - address: 104 W. North St.
     building: ''
     city: Normal
@@ -4725,6 +5093,7 @@
     zip: '61761'
     latitude: 40.5094581
     longitude: -88.9846312
+    id: D000619-normal
   - address: 2833 S Grand Ave. East
     building: ''
     city: Springfield
@@ -4736,6 +5105,7 @@
     zip: '62703'
     latitude: 39.7888553
     longitude: -89.6124109
+    id: D000619-springfield
   - address: 108 W. Market St.
     building: ''
     city: Taylorville
@@ -4747,6 +5117,7 @@
     zip: '62568'
     latitude: 39.5480891
     longitude: -89.29549949999999
+    id: D000619-taylorville
 - id:
     bioguide: D000620
     govtrack: 412544
@@ -4763,6 +5134,7 @@
     zip: '20878'
     latitude: 39.1148145
     longitude: -77.196095
+    id: D000620-gaithersburg
   - address: 38 S. Potomac St.
     building: ''
     city: Hagerstown
@@ -4774,6 +5146,7 @@
     zip: '21740'
     latitude: 39.6410348
     longitude: -77.7207337
+    id: D000620-hagerstown
 - id:
     bioguide: D000621
     govtrack: 412526
@@ -4790,6 +5163,7 @@
     zip: '32129'
     latitude: 29.1265173
     longitude: -81.02072489999999
+    id: D000621-port_orange
   - address: 3940 Speedway
     building: ''
     city: St. Augustine
@@ -4801,6 +5175,7 @@
     zip: '32084'
     latitude: 29.9393092
     longitude: -81.339015
+    id: D000621-st__augustine
 - id:
     bioguide: D000623
     govtrack: 412613
@@ -4817,6 +5192,7 @@
     zip: '94804'
     latitude: 37.9367699
     longitude: -122.3428337
+    id: D000623-richmond
   - address: 101 Ygnacio Valley Rd.
     building: ''
     city: Walnut Creek
@@ -4828,6 +5204,7 @@
     zip: '94596'
     latitude: 37.9043441
     longitude: -122.0688945
+    id: D000623-walnut_creek
 - id:
     bioguide: D000624
     govtrack: 412637
@@ -4844,6 +5221,7 @@
     zip: '48124'
     latitude: 42.3034918
     longitude: -83.2627983
+    id: D000624-dearborn
   - address: 301 W. Michigan Ave.
     building: ''
     city: Ypsilanti
@@ -4855,6 +5233,7 @@
     zip: '48197'
     latitude: 42.24069780000001
     longitude: -83.6164891
+    id: D000624-ypsilanti
 - id:
     bioguide: D000625
     govtrack: 412672
@@ -4871,6 +5250,7 @@
     zip: '11228'
     latitude: 40.6213928
     longitude: -74.0066707
+    id: D000625-brooklyn
   - address: 265 New Dorp Ln.
     building: ''
     city: Staten Island
@@ -4882,6 +5262,7 @@
     zip: '10306'
     latitude: 40.5725536
     longitude: -74.1132361
+    id: D000625-staten_island
 - id:
     bioguide: D000626
     govtrack: 412675
@@ -4898,6 +5279,7 @@
     zip: '45502'
     latitude: 39.9237363
     longitude: -83.80971939999999
+    id: D000626-springfield
   - address: 12 S. Plum St.
     building: ''
     city: Troy
@@ -4909,6 +5291,7 @@
     zip: '45373'
     latitude: 40.0401311
     longitude: -84.20569890000002
+    id: D000626-troy
   - address: 8857 Cincinnati-Dayton Rd.
     building: ''
     city: West Chester
@@ -4920,6 +5303,7 @@
     zip: '45069'
     latitude: 39.33175850000001
     longitude: -84.4066223
+    id: D000626-west_chester
 - id:
     bioguide: D000627
     govtrack: 412696
@@ -4935,6 +5319,7 @@
     zip: '32835'
     latitude: 28.517804
     longitude: -81.48186439999999
+    id: D000627-orlando
 - id:
     bioguide: D000628
     govtrack: 412691
@@ -4950,6 +5335,7 @@
     zip: '32401'
     latitude: 30.167961
     longitude: -85.67189499999999
+    id: D000628-panama_city
   - address: 300 S. Adams St.
     building: ''
     city: Tallahassee
@@ -4961,6 +5347,7 @@
     zip: '32301'
     latitude: 30.4395286
     longitude: -84.2826688
+    id: D000628-tallahassee
 - id:
     bioguide: E000179
     govtrack: 400122
@@ -4977,6 +5364,7 @@
     zip: '10475'
     latitude: 40.8777838
     longitude: -73.82924609999999
+    id: E000179-bronx
   - address: 3655 Johnson Ave.
     building: ''
     city: Bronx
@@ -4988,6 +5376,7 @@
     zip: '10463'
     latitude: 40.8881337
     longitude: -73.90958499999999
+    id: E000179-bronx-1
   - address: 6 Gramatan Ave.
     building: ''
     city: Mt. Vernon
@@ -4999,6 +5388,7 @@
     zip: '10550'
     latitude: 40.9124845
     longitude: -73.8376727
+    id: E000179-mt__vernon
 - id:
     bioguide: E000215
     govtrack: 400124
@@ -5015,6 +5405,7 @@
     zip: '94301'
     latitude: 37.4431725
     longitude: -122.1606451
+    id: E000215-palo_alto
 - id:
     bioguide: E000285
     govtrack: 300041
@@ -5031,6 +5422,7 @@
     zip: '82601'
     latitude: 42.8524124
     longitude: -106.3248373
+    id: E000285-casper
   - address: 2120 Capitol Ave.
     building: Federal Center
     city: Cheyenne
@@ -5042,6 +5434,7 @@
     zip: '82001'
     latitude: 41.1374591
     longitude: -104.8189674
+    id: E000285-cheyenne
   - address: 1285 Sheridan Ave.
     building: ''
     city: Cody
@@ -5053,6 +5446,7 @@
     zip: '82414'
     latitude: 44.52606979999999
     longitude: -109.0624068
+    id: E000285-cody
   - address: 222 S. Gillette Ave.
     building: '503'
     city: Gillette
@@ -5064,6 +5458,7 @@
     zip: '82716'
     latitude: 44.2924295
     longitude: -105.5045976
+    id: E000285-gillette
   - address: 1110 Maple Way
     building: P.O. Box 12470
     city: Jackson
@@ -5075,6 +5470,7 @@
     zip: '83002'
     latitude: 43.47006589999999
     longitude: -110.7872894
+    id: E000285-jackson
 - id:
     bioguide: E000288
     govtrack: 412215
@@ -5091,6 +5487,7 @@
     zip: '55411'
     latitude: 44.9918557
     longitude: -93.30716609999999
+    id: E000288-minneapolis
 - id:
     bioguide: E000293
     govtrack: 412524
@@ -5107,6 +5504,7 @@
     zip: '06053'
     latitude: 41.6706549
     longitude: -72.7867265
+    id: E000293-new_britain
 - id:
     bioguide: E000294
     govtrack: 412639
@@ -5123,6 +5521,7 @@
     zip: '55330'
     latitude: 45.2839958
     longitude: -93.5648066
+    id: E000294-otsego
 - id:
     bioguide: E000295
     govtrack: 412667
@@ -5139,6 +5538,7 @@
     zip: '52401'
     latitude: 41.9731139
     longitude: -91.6645212
+    id: E000295-cedar_rapids
   - address: 8 S. Sixth St.
     building: 221 Federal Building
     city: Council Bluffs
@@ -5150,6 +5550,7 @@
     zip: '51501'
     latitude: 41.2608863
     longitude: -95.8525576
+    id: E000295-council_bluffs
   - address: 201 W. Second St.
     building: ''
     city: Davenport
@@ -5161,6 +5562,7 @@
     zip: '52801'
     latitude: 41.5213296
     longitude: -90.5758645
+    id: E000295-davenport
   - address: 210 Walnut St.
     building: 733 Federal Building
     city: Des Moines
@@ -5172,6 +5574,7 @@
     zip: '50309'
     latitude: 41.5864152
     longitude: -93.62015319999999
+    id: E000295-des_moines
   - address: 320 Sixth St.
     building: 194 Federal Building
     city: Sioux City
@@ -5183,6 +5586,7 @@
     zip: '51101'
     latitude: 42.4963261
     longitude: -96.40758369999999
+    id: E000295-sioux_city
 - id:
     bioguide: E000296
     govtrack: 412677
@@ -5198,6 +5602,7 @@
     zip: '19138'
     latitude: 40.063831
     longitude: -75.153345
+    id: E000296-philadelphia
 - id:
     bioguide: F000062
     govtrack: 300043
@@ -5214,6 +5619,7 @@
     zip: '93721'
     latitude: 36.7374775
     longitude: -119.7836709
+    id: F000062-fresno
   - address: 11111 Santa Monica Blvd.
     building: ''
     city: Los Angeles
@@ -5225,6 +5631,7 @@
     zip: '90025'
     latitude: 34.0476223
     longitude: -118.444656
+    id: F000062-los_angeles
   - address: 880 Front St.
     building: ''
     city: San Diego
@@ -5236,6 +5643,7 @@
     zip: '92101'
     latitude: 32.7143481
     longitude: -117.1647085
+    id: F000062-san_diego
   - address: One Post Street
     building: ''
     city: San Francisco
@@ -5247,6 +5655,7 @@
     zip: '94104'
     latitude: 37.7887748
     longitude: -122.4026656
+    id: F000062-san_francisco
 - id:
     bioguide: F000372
     govtrack: 400142
@@ -5263,6 +5672,7 @@
     zip: '07960'
     latitude: 40.7964119
     longitude: -74.4835583
+    id: F000372-morristown
 - id:
     bioguide: F000444
     govtrack: 400134
@@ -5279,6 +5689,7 @@
     zip: '85016'
     latitude: 33.5098565
     longitude: -112.0338808
+    id: F000444-phoenix
   - address: 6840 N. Oracle Rd.
     building: ''
     city: Tucson
@@ -5290,6 +5701,7 @@
     zip: '85704'
     latitude: 32.3316739
     longitude: -110.976131
+    id: F000444-tucson
 - id:
     bioguide: F000448
     govtrack: 400141
@@ -5306,6 +5718,7 @@
     zip: '85308'
     latitude: 33.6372922
     longitude: -112.2108385
+    id: F000448-glendale
 - id:
     bioguide: F000449
     govtrack: 400640
@@ -5322,6 +5735,7 @@
     zip: '68026'
     latitude: 41.43559459999999
     longitude: -96.49880739999999
+    id: F000449-fremont
   - address: 301 S. 13th St.
     building: ''
     city: Lincoln
@@ -5333,6 +5747,7 @@
     zip: '68508'
     latitude: 40.8108404
     longitude: -96.7033345
+    id: F000449-lincoln
   - address: 506 W. Madison Ave.
     building: ''
     city: Norfolk
@@ -5344,6 +5759,7 @@
     zip: '68701'
     latitude: 42.0317036
     longitude: -97.4144702
+    id: F000449-norfolk
 - id:
     bioguide: F000450
     govtrack: 400643
@@ -5360,6 +5776,7 @@
     zip: '28607'
     latitude: 36.2033658
     longitude: -81.65849589999999
+    id: F000450-boone
   - address: 3540 Clemmons Rd.
     building: ''
     city: Clemmons
@@ -5371,6 +5788,7 @@
     zip: '27012'
     latitude: 36.0225285
     longitude: -80.3758084
+    id: F000450-clemmons
 - id:
     bioguide: F000454
     govtrack: 412257
@@ -5387,6 +5805,7 @@
     zip: '60502'
     latitude: 41.758276
     longitude: -88.249771
+    id: F000454-aurora
   - address: 195 Springfield Ave.
     building: ''
     city: Joliet
@@ -5398,6 +5817,7 @@
     zip: '60435'
     latitude: 41.52538759999999
     longitude: -88.1380854
+    id: F000454-joliet
 - id:
     bioguide: F000455
     govtrack: 412327
@@ -5414,6 +5834,7 @@
     zip: '44320'
     latitude: 41.080905
     longitude: -81.565018
+    id: F000455-akron
   - address: 4834 Richmond Rd.
     building: ''
     city: Warrensville Heights
@@ -5425,6 +5846,7 @@
     zip: '44128'
     latitude: 41.4286825
     longitude: -81.4985324
+    id: F000455-warrensville_heights
 - id:
     bioguide: F000457
     govtrack: 412378
@@ -5441,6 +5863,7 @@
     zip: '55802'
     latitude: 46.7825784
     longitude: -92.10688909999999
+    id: F000457-duluth
   - address: 819 Center Ave.
     building: ''
     city: Moorhead
@@ -5452,6 +5875,7 @@
     zip: '56560'
     latitude: 46.8750559
     longitude: -96.7677958
+    id: F000457-moorhead
   - address: 1202-1/2 7th Street NW
     building: ''
     city: Rochester
@@ -5463,6 +5887,7 @@
     zip: '55901'
     latitude: 44.0316171
     longitude: -92.4806419
+    id: F000457-rochester
   - address: 60 E. Plato Blvd.
     building: ''
     city: Saint Paul
@@ -5474,6 +5899,7 @@
     zip: '55107'
     latitude: 44.9373985
     longitude: -93.08430109999999
+    id: F000457-saint_paul
 - id:
     bioguide: F000459
     govtrack: 412476
@@ -5490,6 +5916,7 @@
     zip: '37303'
     latitude: 35.441192
     longitude: -84.594681
+    id: F000459-athens
   - address: 900 Georgia Ave.
     building: ''
     city: Chattanooga
@@ -5501,6 +5928,7 @@
     zip: '37402'
     latitude: 35.0450875
     longitude: -85.3082146
+    id: F000459-chattanooga
   - address: 200 Administration Rd.
     building: ''
     city: Oak Ridge
@@ -5512,6 +5940,7 @@
     zip: '37830'
     latitude: 36.02409
     longitude: -84.23490799999999
+    id: F000459-oak_ridge
 - id:
     bioguide: F000460
     govtrack: 412482
@@ -5528,6 +5957,7 @@
     zip: '78401'
     latitude: 27.7917948
     longitude: -97.3931982
+    id: F000460-corpus_christi
   - address: 5606 N. Navarro St.
     building: ''
     city: Victoria
@@ -5539,6 +5969,7 @@
     zip: '77904'
     latitude: 28.8476874
     longitude: -96.9978986
+    id: F000460-victoria
 - id:
     bioguide: F000461
     govtrack: 412480
@@ -5555,6 +5986,7 @@
     zip: '78728'
     latitude: 30.4436527
     longitude: -97.69572099999999
+    id: F000461-austin
   - address: 3000 Briarcrest Dr.
     building: ''
     city: Bryan
@@ -5566,6 +5998,7 @@
     zip: '77802'
     latitude: 30.6609467
     longitude: -96.328648
+    id: F000461-bryan
   - address: 400 Austin Ave.
     building: ''
     city: Waco
@@ -5577,6 +6010,7 @@
     zip: '76701'
     latitude: 31.5572533
     longitude: -97.130924
+    id: F000461-waco
 - id:
     bioguide: F000462
     govtrack: 412529
@@ -5593,6 +6027,7 @@
     zip: '33431'
     latitude: 26.3730924
     longitude: -80.1203093
+    id: F000462-boca_raton
 - id:
     bioguide: F000463
     govtrack: 412556
@@ -5609,6 +6044,7 @@
     zip: '68847'
     latitude: 40.6986843
     longitude: -99.0819184
+    id: F000463-kearney
   - address: 440 N. 8th St.
     building: ''
     city: Lincoln
@@ -5620,6 +6056,7 @@
     zip: '68508'
     latitude: 40.8177383
     longitude: -96.7095183
+    id: F000463-lincoln
   - address: 11819 Miracle Hills Drive
     building: ''
     city: Omaha
@@ -5631,6 +6068,7 @@
     zip: '68154'
     latitude: 41.26733180000001
     longitude: -96.0980857
+    id: F000463-omaha
   - address: 1110 Circle Dr.
     building: ''
     city: Scottsbluff
@@ -5642,6 +6080,7 @@
     zip: '69361'
     latitude: 41.8680501
     longitude: -103.6483008
+    id: F000463-scottsbluff
 - id:
     bioguide: F000464
     govtrack: 412719
@@ -5657,6 +6096,7 @@
     zip: '13753'
     latitude: 42.2774942
     longitude: -74.9160098
+    id: F000464-delhi
   - address: 2 Hudson St.
     building: ''
     city: Kinderhook
@@ -5668,6 +6108,7 @@
     zip: '12106'
     latitude: 42.3947969
     longitude: -73.698395
+    id: F000464-kinderhook
   - address: 721 Broadway
     building: ''
     city: Kingston
@@ -5679,6 +6120,7 @@
     zip: '12401'
     latitude: 41.9310395
     longitude: -74.00980260000001
+    id: F000464-kingston
 - id:
     bioguide: F000465
     govtrack: 412700
@@ -5694,6 +6136,7 @@
     zip: '30265'
     latitude: 33.3996108
     longitude: -84.72636159999999
+    id: F000465-newnan
 - id:
     bioguide: F000466
     govtrack: 412721
@@ -5709,6 +6152,7 @@
     zip: '19047'
     latitude: 40.2162341
     longitude: -74.9308492
+    id: F000466-langhorne
 - id:
     bioguide: G000289
     govtrack: 400154
@@ -5725,6 +6169,7 @@
     zip: '22802'
     latitude: 38.4496778
     longitude: -78.8661965
+    id: G000289-harrisonburg
   - address: 916 Main St.
     building: ''
     city: Lynchburg
@@ -5736,6 +6181,7 @@
     zip: '24504'
     latitude: 37.4144164
     longitude: -79.1415629
+    id: G000289-lynchburg
   - address: 10 Franklin Rd.
     building: ''
     city: Roanoke
@@ -5747,6 +6193,7 @@
     zip: '24011'
     latitude: 37.2696634
     longitude: -79.93993569999999
+    id: G000289-roanoke
   - address: 117 S. Lewis St.
     building: ''
     city: Staunton
@@ -5758,6 +6205,7 @@
     zip: '24401'
     latitude: 38.1477382
     longitude: -79.0742178
+    id: G000289-staunton
 - id:
     bioguide: G000359
     govtrack: 300047
@@ -5774,6 +6222,7 @@
     zip: '29201'
     latitude: 34.0016459
     longitude: -81.0461408
+    id: G000359-columbia
   - address: 401 W. Evans St.
     building: McMillan Federal Building
     city: Florence
@@ -5785,6 +6234,7 @@
     zip: '29501'
     latitude: 34.1974074
     longitude: -79.7733804
+    id: G000359-florence
   - address: 130 S. Main St.
     building: ''
     city: Greenville
@@ -5796,6 +6246,7 @@
     zip: '29601'
     latitude: 34.84875359999999
     longitude: -82.4004437
+    id: G000359-greenville
   - address: 530 Johnnie Dodds Blvd.
     building: ''
     city: Mt. Pleasant
@@ -5807,6 +6258,7 @@
     zip: '29464'
     latitude: 32.8060149
     longitude: -79.88793369999999
+    id: G000359-mt__pleasant
   - address: 124 Exchange St.
     building: ''
     city: Pendleton
@@ -5818,6 +6270,7 @@
     zip: '29670'
     latitude: 34.65072
     longitude: -82.782997
+    id: G000359-pendleton
   - address: 235 E. Main St.
     building: ''
     city: Rock Hill
@@ -5829,6 +6282,7 @@
     zip: '29730'
     latitude: 34.9245162
     longitude: -81.0247705
+    id: G000359-rock_hill
 - id:
     bioguide: G000377
     govtrack: 400157
@@ -5845,6 +6299,7 @@
     zip: '76107'
     latitude: 32.7270777
     longitude: -97.3597301
+    id: G000377-fort_worth
 - id:
     bioguide: G000386
     govtrack: 300048
@@ -5861,6 +6316,7 @@
     zip: '52401'
     latitude: 41.9731139
     longitude: -91.6645212
+    id: G000386-cedar_rapids
   - address: 8 S. 6th St.
     building: 307 Federal Building
     city: Council Bluffs
@@ -5872,6 +6328,7 @@
     zip: '51501'
     latitude: 41.2608863
     longitude: -95.8525576
+    id: G000386-council_bluffs
   - address: 201 W. 2nd St.
     building: ''
     city: Davenport
@@ -5883,6 +6340,7 @@
     zip: '52801'
     latitude: 41.5213296
     longitude: -90.5758645
+    id: G000386-davenport
   - address: 210 Walnut St.
     building: 721 Federal Building
     city: Des Moines
@@ -5894,6 +6352,7 @@
     zip: '50309'
     latitude: 41.5864152
     longitude: -93.62015319999999
+    id: G000386-des_moines
   - address: 320 6th St.
     building: 120 Federal Building
     city: Sioux City
@@ -5905,6 +6364,7 @@
     zip: '51101'
     latitude: 42.4963261
     longitude: -96.40758369999999
+    id: G000386-sioux_city
   - address: 531 Commercial St.
     building: ''
     city: Waterloo
@@ -5916,6 +6376,7 @@
     zip: '50701'
     latitude: 42.4953784
     longitude: -92.339384
+    id: G000386-waterloo
 - id:
     bioguide: G000410
     govtrack: 400160
@@ -5932,6 +6393,7 @@
     zip: '77060'
     latitude: 29.9398853
     longitude: -95.4046901
+    id: G000410-houston
   - address: 11811 East Freeway
     building: ''
     city: Houston
@@ -5943,6 +6405,7 @@
     zip: '77029'
     latitude: 29.771125
     longitude: -95.224792
+    id: G000410-houston-1
 - id:
     bioguide: G000535
     govtrack: 400163
@@ -5959,6 +6422,7 @@
     zip: '60647'
     latitude: 41.9249703
     longitude: -87.7091868
+    id: G000535-chicago
 - id:
     bioguide: G000546
     govtrack: 400158
@@ -5975,6 +6439,7 @@
     zip: '63401'
     latitude: 39.7065377
     longitude: -91.36431680000001
+    id: G000546-hannibal
   - address: 11724 NW Plaza Circle
     building: ''
     city: Kansas City
@@ -5986,6 +6451,7 @@
     zip: '64153'
     latitude: 39.3060799
     longitude: -94.68496599999999
+    id: G000546-kansas_city
   - address: 411 Jules St.
     building: ''
     city: St. Joseph
@@ -5997,6 +6463,7 @@
     zip: '64501'
     latitude: 39.7685973
     longitude: -94.8548563
+    id: G000546-st__joseph
 - id:
     bioguide: G000551
     govtrack: 400162
@@ -6013,6 +6480,7 @@
     zip: '85323'
     latitude: 33.4487419
     longitude: -112.3501093
+    id: G000551-avondale
   - address: 146 N. State Ave.
     building: ''
     city: Somerton
@@ -6024,6 +6492,7 @@
     zip: '85350'
     latitude: 32.5960917
     longitude: -114.7109846
+    id: G000551-somerton
   - address: 101 W. Irvington Road
     building: El Pueblo Community Center
     city: Tucson
@@ -6035,6 +6504,7 @@
     zip: '85714'
     latitude: 32.163554
     longitude: -110.969568
+    id: G000551-tucson
 - id:
     bioguide: G000552
     govtrack: 400651
@@ -6051,6 +6521,7 @@
     zip: '75601'
     latitude: 32.4970151
     longitude: -94.73894650000001
+    id: G000552-longview
   - address: 300 E. Shepherd
     building: ''
     city: Lufkin
@@ -6062,6 +6533,7 @@
     zip: '75901'
     latitude: 31.3368848
     longitude: -94.7268845
+    id: G000552-lufkin
   - address: 102 W. Houston St.
     building: ''
     city: Marshall
@@ -6073,6 +6545,7 @@
     zip: '75670'
     latitude: 32.5447093
     longitude: -94.36734899999999
+    id: G000552-marshall
   - address: 101 W. Main
     building: ''
     city: Nacogdoches
@@ -6084,6 +6557,7 @@
     zip: '75961'
     latitude: 31.6036806
     longitude: -94.6565524
+    id: G000552-nacogdoches
   - address: 1121 ESE Loop 323
     building: ''
     city: Tyler
@@ -6095,6 +6569,7 @@
     zip: '75701'
     latitude: 32.3031236
     longitude: -95.28684349999999
+    id: G000552-tyler
 - id:
     bioguide: G000553
     govtrack: 400653
@@ -6111,6 +6586,7 @@
     zip: '77054'
     latitude: 29.6765115
     longitude: -95.4252617
+    id: G000553-houston
 - id:
     bioguide: G000555
     govtrack: 412223
@@ -6127,6 +6603,7 @@
     zip: '12207'
     latitude: 42.655222
     longitude: -73.7492819
+    id: G000555-albany
   - address: 726 Exchange St.
     building: Larkin At Exchange
     city: Buffalo
@@ -6138,6 +6615,7 @@
     zip: '14210'
     latitude: 42.8747911
     longitude: -78.851165
+    id: G000555-buffalo
   - address: PO Box 273
     building: ''
     city: Lowville
@@ -6149,6 +6627,7 @@
     zip: '13367'
     latitude: 43.786736
     longitude: -75.4918505
+    id: G000555-lowville
   - address: PO Box 893
     building: ''
     city: Mahopac
@@ -6160,6 +6639,7 @@
     zip: '10541'
     latitude: 41.372316
     longitude: -73.733465
+    id: G000555-mahopac
   - address: 780 Third Ave.
     building: ''
     city: New York
@@ -6171,6 +6651,7 @@
     zip: '10017'
     latitude: 40.7550353
     longitude: -73.97185879999999
+    id: G000555-new_york
   - address: 155 Pinelawn Rd.
     building: ''
     city: Melville
@@ -6182,6 +6663,7 @@
     zip: '11747'
     latitude: 40.7707877
     longitude: -73.41024759999999
+    id: G000555-melville
   - address: 100 State St.
     building: Kenneth B. Keating Federal Office Building
     city: Rochester
@@ -6193,6 +6675,7 @@
     zip: '14614'
     latitude: 43.1576631
     longitude: -77.613515
+    id: G000555-rochester
   - address: 100 S. Clinton St.
     building: James M. Hanley Federal Building
     city: Syracuse
@@ -6204,6 +6687,7 @@
     zip: '13261'
     latitude: 43.0501042
     longitude: -76.1543204
+    id: G000555-syracuse
 - id:
     bioguide: G000558
     govtrack: 412278
@@ -6220,6 +6704,7 @@
     zip: '42103'
     latitude: 36.9671412
     longitude: -86.4282633
+    id: G000558-bowling_green
   - address: 2200 Airport Rd.
     building: ''
     city: Owensboro
@@ -6231,6 +6716,7 @@
     zip: '42301'
     latitude: 37.7493662
     longitude: -87.1617598
+    id: G000558-owensboro
   - address: 411 W. Lincoln Trail Blvd.
     building: ''
     city: Radcliff
@@ -6242,6 +6728,7 @@
     zip: '40160'
     latitude: 37.8379989
     longitude: -85.9440374
+    id: G000558-radcliff
 - id:
     bioguide: G000559
     govtrack: 412382
@@ -6258,6 +6745,7 @@
     zip: '95616'
     latitude: 38.5466673
     longitude: -121.7395708
+    id: G000559-davis
   - address: 1261 Travis Blvd.
     building: ''
     city: Fairfield
@@ -6269,6 +6757,7 @@
     zip: '94533'
     latitude: 38.2576953
     longitude: -122.0494716
+    id: G000559-fairfield
   - address: 795 Plumas St.
     building: ''
     city: Yuba City
@@ -6280,6 +6769,7 @@
     zip: '95991'
     latitude: 39.1396913
     longitude: -121.6173255
+    id: G000559-yuba_city
 - id:
     bioguide: G000560
     govtrack: 412388
@@ -6296,6 +6786,7 @@
     zip: '30720'
     latitude: 34.7627274
     longitude: -84.9720332
+    id: G000560-dalton
   - address: 600 E. First St.
     building: ''
     city: Rome
@@ -6307,6 +6798,7 @@
     zip: '30161'
     latitude: 34.2553159
     longitude: -85.1670568
+    id: G000560-rome
 - id:
     bioguide: G000562
     govtrack: 412406
@@ -6323,6 +6815,7 @@
     zip: '80903'
     latitude: 38.83199949999999
     longitude: -104.8240571
+    id: G000562-colorado_springs
   - address: 1125 17th St.
     building: ''
     city: Denver
@@ -6334,6 +6827,7 @@
     zip: '80202'
     latitude: 39.7494865
     longitude: -104.994834
+    id: G000562-denver
   - address: 329 Rio
     building: ''
     city: Durango
@@ -6345,6 +6839,7 @@
     zip: '81303'
     latitude: 37.2509136
     longitude: -107.8778701
+    id: G000562-durango
   - address: 2001 S. Shields St.
     building: Building H
     city: Fort Collins
@@ -6356,6 +6851,7 @@
     zip: '80526'
     latitude: 40.5607326
     longitude: -105.0969106
+    id: G000562-fort_collins
   - address: 400 Rood Ave.
     building: Federal Bldg., Ste. 220
     city: Grand Junction
@@ -6367,6 +6863,7 @@
     zip: '81501'
     latitude: 39.06856490000001
     longitude: -108.5657085
+    id: G000562-grand_junction
   - address: 801 8th St.
     building: ''
     city: Greeley
@@ -6378,6 +6875,7 @@
     zip: '80631'
     latitude: 40.425174
     longitude: -104.6910459
+    id: G000562-greeley
   - address: 503 N. Main St.
     building: ''
     city: Pueblo
@@ -6389,6 +6887,7 @@
     zip: '81003'
     latitude: 38.27203069999999
     longitude: -104.60937
+    id: G000562-pueblo
   - address: 529 N. Albany St.
     building: ''
     city: Yuma
@@ -6400,6 +6899,7 @@
     zip: '80759'
     latitude: 40.1304123
     longitude: -102.7221695
+    id: G000562-yuma
 - id:
     bioguide: G000563
     govtrack: 412463
@@ -6416,6 +6916,7 @@
     zip: '44805'
     latitude: 40.86905120000001
     longitude: -82.31826099999999
+    id: G000563-ashland
   - address: 110 Central Plaza South
     building: ''
     city: Canton
@@ -6427,6 +6928,7 @@
     zip: '44702'
     latitude: 40.797956
     longitude: -81.37428899999999
+    id: G000563-canton
 - id:
     bioguide: G000565
     govtrack: 412397
@@ -6441,6 +6943,7 @@
     state: AZ
     suite: ''
     zip: '86401'
+    id: G000565-kingman
   - address: 6499 S. Kings Ranch Rd.
     building: ''
     city: Gold Canyon
@@ -6452,6 +6955,7 @@
     zip: '85118'
     latitude: 33.3557193
     longitude: -111.4526421
+    id: G000565-gold_canyon
   - address: 122 N. Cortez St.
     building: ''
     city: Prescott
@@ -6463,6 +6967,7 @@
     zip: '86301'
     latitude: 34.5427185
     longitude: -112.4690897
+    id: G000565-prescott
 - id:
     bioguide: G000566
     govtrack: 412473
@@ -6479,6 +6984,7 @@
     zip: '29601'
     latitude: 34.849407
     longitude: -82.40024
+    id: G000566-greenville
   - address: 101 W. St John St.
     building: ''
     city: Spartanburg
@@ -6490,6 +6996,7 @@
     zip: '29306'
     latitude: 34.9509114
     longitude: -81.9333968
+    id: G000566-spartanburg
 - id:
     bioguide: G000568
     govtrack: 412485
@@ -6506,6 +7013,7 @@
     zip: '24210'
     latitude: 36.7086253
     longitude: -81.98113049999999
+    id: G000568-abingdon
   - address: 322 E. Wood Ave
     building: Federal Courthouse
     city: Big Stone Gap
@@ -6515,6 +7023,7 @@
     state: VA
     suite: ''
     zip: '24219'
+    id: G000568-big_stone_gap
   - address: 17 W. Main St.
     building: ''
     city: Christiansburg
@@ -6526,6 +7035,7 @@
     zip: '24073'
     latitude: 37.1296267
     longitude: -80.4095978
+    id: G000568-christiansburg
 - id:
     bioguide: G000571
     govtrack: 412532
@@ -6542,6 +7052,7 @@
     zip: '96850'
     latitude: 21.3036893
     longitude: -157.862353
+    id: G000571-honolulu
 - id:
     bioguide: G000574
     govtrack: 412612
@@ -6558,6 +7069,7 @@
     zip: '85004'
     latitude: 33.452957
     longitude: -112.0734511
+    id: G000574-phoenix
 - id:
     bioguide: G000576
     govtrack: 412661
@@ -6574,6 +7086,7 @@
     zip: '54935'
     latitude: 43.7522376
     longitude: -88.4509945
+    id: G000576-fond_du_lac
 - id:
     bioguide: G000577
     govtrack: 412631
@@ -6590,6 +7103,7 @@
     zip: '70808'
     latitude: 30.4265187
     longitude: -91.1316524
+    id: G000577-baton_rouge
   - address: 29261 Frost Rd.
     building: Livingston Parish Government Building
     city: Livingston
@@ -6601,6 +7115,7 @@
     zip: '70754'
     latitude: 30.48302409999999
     longitude: -90.7486419
+    id: G000577-livingston
   - address: 908 E. 1st St.
     building: NSU Campus, Candies Hall
     city: Thibodaux
@@ -6612,6 +7127,7 @@
     zip: '70301'
     latitude: 29.795623
     longitude: -90.8011997
+    id: G000577-thibodaux
 - id:
     bioguide: G000578
     govtrack: 412690
@@ -6627,6 +7143,7 @@
     zip: '32502'
     latitude: 30.4094471
     longitude: -87.2142552
+    id: G000578-pensacola
 - id:
     bioguide: G000579
     govtrack: 412731
@@ -6642,6 +7159,7 @@
     zip: '54911'
     latitude: 44.2614778
     longitude: -88.4094435
+    id: G000579-appleton
 - id:
     bioguide: G000580
     govtrack: 412729
@@ -6657,6 +7175,7 @@
     zip: '22901'
     latitude: 38.0847006
     longitude: -78.47843069999999
+    id: G000580-charlottesville
   - address: 308 Craghead St.
     building: ''
     city: Danville
@@ -6668,6 +7187,7 @@
     zip: '24541'
     latitude: 36.5867166
     longitude: -79.38939599999999
+    id: G000580-danville
 - id:
     bioguide: G000581
     govtrack: 412725
@@ -6683,6 +7203,7 @@
     zip: '78539'
     latitude: 26.2658508
     longitude: -98.20102790000001
+    id: G000581-edinburg
 - id:
     bioguide: G000582
     govtrack: 412723
@@ -6698,6 +7219,7 @@
     zip: '00901'
     latitude: 18.4669792
     longitude: -66.1040007
+    id: G000582-san_juan
 - id:
     bioguide: G000583
     govtrack: 412714
@@ -6713,6 +7235,7 @@
     zip: '07452'
     latitude: 40.9506625
     longitude: -74.143801
+    id: G000583-glen_rock
 - id:
     bioguide: H000324
     govtrack: 400170
@@ -6729,6 +7252,7 @@
     zip: '33311'
     latitude: 26.165965
     longitude: -80.1797155
+    id: H000324-fort_lauderdale
   - address: 1755 E. Tiffany Dr.
     building: Town of Mangonia Park Municipal Center
     city: Mangonia Park
@@ -6740,6 +7264,7 @@
     zip: '33407'
     latitude: 26.7555179
     longitude: -80.081968
+    id: H000324-mangonia_park
 - id:
     bioguide: H000338
     govtrack: 300052
@@ -6756,6 +7281,7 @@
     zip: '84720'
     latitude: 37.67872819999999
     longitude: -113.0619776
+    id: H000338-cedar_city
   - address: 324 25th St.
     building: 1006 Federal Building
     city: Ogden
@@ -6767,6 +7293,7 @@
     zip: '84401'
     latitude: 41.2206774
     longitude: -111.9726125
+    id: H000338-ogden
   - address: 51 S. University Ave.
     building: ''
     city: Provo
@@ -6778,6 +7305,7 @@
     zip: '84601'
     latitude: 40.232986
     longitude: -111.6578512
+    id: H000338-provo
   - address: 125 S. State St.
     building: 8402 Federal Building
     city: Salt Lake City
@@ -6789,6 +7317,7 @@
     zip: '84138'
     latitude: 40.7667476
     longitude: -111.8871382
+    id: H000338-salt_lake_city
   - address: 196 E. Tabernacle
     building: Federal Building
     city: St. George
@@ -6800,6 +7329,7 @@
     zip: '84770'
     latitude: 37.107876
     longitude: -113.579673
+    id: H000338-st__george
 - id:
     bioguide: H000874
     govtrack: 400189
@@ -6816,6 +7346,7 @@
     zip: '20770'
     latitude: 39.0089504
     longitude: -76.8952351
+    id: H000874-greenbelt
   - address: 401 Post Office Rd.
     building: ''
     city: Waldorf
@@ -6827,6 +7358,7 @@
     zip: '20602'
     latitude: 38.6112157
     longitude: -76.9022185
+    id: H000874-waldorf
 - id:
     bioguide: H001036
     govtrack: 400175
@@ -6843,6 +7375,7 @@
     zip: '75751'
     latitude: 32.2039064
     longitude: -95.8422855
+    id: H001036-athens
   - address: 6510 Abrams Rd.
     building: ''
     city: Dallas
@@ -6854,6 +7387,7 @@
     zip: '75231'
     latitude: 32.8630659
     longitude: -96.7436031
+    id: H001036-dallas
 - id:
     bioguide: H001038
     govtrack: 400641
@@ -6870,6 +7404,7 @@
     zip: '14210'
     latitude: 42.8747911
     longitude: -78.851165
+    id: H001038-buffalo
   - address: 800 Main St.
     building: ''
     city: Niagara Falls
@@ -6881,6 +7416,7 @@
     zip: '14301'
     latitude: 43.09677019999999
     longitude: -79.0554227
+    id: H001038-niagara_falls
 - id:
     bioguide: H001041
     govtrack: 412218
@@ -6897,6 +7433,7 @@
     zip: '89148'
     latitude: 36.0718617
     longitude: -115.2870903
+    id: H001041-las_vegas
   - address: 400 S. Virginia St.
     building: Bruce Thompson Federal Building
     city: Reno
@@ -6908,6 +7445,7 @@
     zip: '89501'
     latitude: 39.5215352
     longitude: -119.810287
+    id: H001041-reno
 - id:
     bioguide: H001042
     govtrack: 412200
@@ -6924,6 +7462,7 @@
     zip: '96850'
     latitude: 21.3036893
     longitude: -157.862353
+    id: H001042-honolulu
 - id:
     bioguide: H001045
     govtrack: 412280
@@ -6940,6 +7479,7 @@
     zip: '39601'
     latitude: 31.5774837
     longitude: -90.44402009999999
+    id: H001045-brookhaven
   - address: 1901 Front St.
     building: ''
     city: Meridian
@@ -6951,6 +7491,7 @@
     zip: '39301'
     latitude: 32.3639891
     longitude: -88.6963131
+    id: H001045-meridian
   - address: 2507-A Old Brandon Rd.
     building: ''
     city: Pearl
@@ -6962,6 +7503,7 @@
     zip: '39208'
     latitude: 32.2751731
     longitude: -90.12966329999999
+    id: H001045-pearl
   - address: 600 Russell St.
     building: The Mill at Mississippi State
     city: Starkville
@@ -6973,6 +7515,7 @@
     zip: '39759'
     latitude: 33.4573663
     longitude: -88.8027055
+    id: H001045-starkville
 - id:
     bioguide: H001046
     govtrack: 412281
@@ -6989,6 +7532,7 @@
     zip: '87102'
     latitude: 35.0833514
     longitude: -106.6521937
+    id: H001046-albuquerque
   - address: 7450 E. Main St.
     building: ''
     city: Farmington
@@ -7000,6 +7544,7 @@
     zip: '87402'
     latitude: 36.7863602
     longitude: -108.1112628
+    id: H001046-farmington
   - address: 505 S. Main St.
     building: Loretto Towne Center
     city: Las Cruces
@@ -7011,6 +7556,7 @@
     zip: '88001'
     latitude: 32.3041597
     longitude: -106.7758242
+    id: H001046-las_cruces
   - address: 200 E. 4th St.
     building: ''
     city: Roswell
@@ -7022,6 +7568,7 @@
     zip: '88201'
     latitude: 33.39647
     longitude: -104.521106
+    id: H001046-roswell
   - address: 123 E. Marcy St.
     building: ''
     city: Santa Fe
@@ -7033,6 +7580,7 @@
     zip: '87501'
     latitude: 35.6889043
     longitude: -105.9354058
+    id: H001046-santa_fe
 - id:
     bioguide: H001047
     govtrack: 412282
@@ -7049,6 +7597,7 @@
     zip: '06604'
     latitude: 41.1763593
     longitude: -73.1898756
+    id: H001047-bridgeport
   - address: 888 Washington Blvd.
     building: ''
     city: Stamford
@@ -7060,6 +7609,7 @@
     zip: '06901'
     latitude: 41.0514745
     longitude: -73.5428955
+    id: H001047-stamford
 - id:
     bioguide: H001048
     govtrack: 412283
@@ -7076,6 +7626,7 @@
     zip: '92020'
     latitude: 32.820926
     longitude: -116.9614599
+    id: H001048-el_cajon
   - address: 41000 Main St.
     building: ''
     city: Temecula
@@ -7087,6 +7638,7 @@
     zip: '92590'
     latitude: 33.4941712
     longitude: -117.1470449
+    id: H001048-temecula
 - id:
     bioguide: H001050
     govtrack: 412418
@@ -7103,6 +7655,7 @@
     zip: '96850'
     latitude: 21.3036893
     longitude: -157.862353
+    id: H001050-honolulu
 - id:
     bioguide: H001052
     govtrack: 412434
@@ -7119,6 +7672,7 @@
     zip: '21014'
     latitude: 39.535151
     longitude: -76.34646289999999
+    id: H001052-bel_air
   - address: 100 Olde Point Village
     building: KENT ISLAND OFFICE
     city: Chester
@@ -7130,6 +7684,7 @@
     zip: '21619'
     latitude: 38.975324
     longitude: -76.28993
+    id: H001052-chester
   - address: 100 E. Main St.
     building: ''
     city: Salisbury
@@ -7141,6 +7696,7 @@
     zip: '21801'
     latitude: 38.3652997
     longitude: -75.600858
+    id: H001052-salisbury
 - id:
     bioguide: H001053
     govtrack: 412444
@@ -7157,6 +7713,7 @@
     zip: '65201'
     latitude: 38.9230515
     longitude: -92.3365352
+    id: H001053-columbia
   - address: 1909 N. Commercial St.
     building: ''
     city: Harrisonville
@@ -7168,6 +7725,7 @@
     zip: '64701'
     latitude: 38.6630256
     longitude: -94.36446319999999
+    id: H001053-harrisonville
   - address: 219 N. Adams St.
     building: ''
     city: Lebanon
@@ -7179,6 +7737,7 @@
     zip: '65536'
     latitude: 37.6821821
     longitude: -92.6645922
+    id: H001053-lebanon
 - id:
     bioguide: H001056
     govtrack: 412486
@@ -7195,6 +7754,7 @@
     zip: '98532'
     latitude: 46.6639928
     longitude: -122.9672327
+    id: H001056-chehalis
   - address: 750 Anderson St.
     building: O.O. Howard House
     city: Vancouver
@@ -7206,6 +7766,7 @@
     zip: '98661'
     latitude: 45.6281298
     longitude: -122.6643142
+    id: H001056-vancouver
 - id:
     bioguide: H001058
     govtrack: 412437
@@ -7222,6 +7783,7 @@
     zip: '49417'
     latitude: 43.0647606
     longitude: -86.23465929999999
+    id: H001058-grand_haven
   - address: 4555 Wilson Ave.
     building: ''
     city: Grandville
@@ -7233,6 +7795,7 @@
     zip: '49418'
     latitude: 42.881882
     longitude: -85.763622
+    id: H001058-grandville
 - id:
     bioguide: H001059
     govtrack: 412422
@@ -7249,6 +7812,7 @@
     zip: '60175'
     latitude: 41.9356063
     longitude: -88.4006984
+    id: H001059-campton_hills
 - id:
     bioguide: H001061
     govtrack: 412494
@@ -7265,6 +7829,7 @@
     zip: '58501'
     latitude: 46.80901129999999
     longitude: -100.7882597
+    id: H001061-bismarck
   - address: 1802 32nd Ave. South
     building: ''
     city: Fargo
@@ -7276,6 +7841,7 @@
     zip: '58103'
     latitude: 46.832277
     longitude: -96.81111949999999
+    id: H001061-fargo
   - address: 102 N. Fourth St.
     building: Federal Building
     city: Grand Forks
@@ -7287,6 +7853,7 @@
     zip: '58203'
     latitude: 47.9255358
     longitude: -97.03273929999999
+    id: H001061-grand_forks
   - address: 100 1st St.
     building: ''
     city: Minot
@@ -7298,6 +7865,7 @@
     zip: '58701'
     latitude: 48.2351551
     longitude: -101.2950057
+    id: H001061-minot
   - address: ''
     building: ''
     city: Williston
@@ -7307,6 +7875,7 @@
     state: ND
     suite: ''
     zip: ''
+    id: H001061-williston
 - id:
     bioguide: H001064
     govtrack: 412584
@@ -7323,6 +7892,7 @@
     zip: '98503'
     latitude: 47.04487049999999
     longitude: -122.8223848
+    id: H001064-lacey
   - address: 6000 Main St.
     building: ''
     city: Lakewood
@@ -7334,6 +7904,7 @@
     zip: '98499'
     latitude: 47.1615029
     longitude: -122.51552
+    id: H001064-lakewood
 - id:
     bioguide: H001065
     govtrack: 412553
@@ -7350,6 +7921,7 @@
     zip: '27830'
     latitude: 35.5436158
     longitude: -77.97435569999999
+    id: H001065-fremont
   - address: 3725 National Dr.
     building: ''
     city: Raleigh
@@ -7361,6 +7933,7 @@
     zip: '27612'
     latitude: 35.8346419
     longitude: -78.6666549
+    id: H001065-raleigh
 - id:
     bioguide: H001067
     govtrack: 412550
@@ -7377,6 +7950,7 @@
     zip: '28027'
     latitude: 35.4150032
     longitude: -80.6027893
+    id: H001067-concord
   - address: 1015 Fayetteville Rd.
     building: ''
     city: Rockingham
@@ -7388,6 +7962,7 @@
     zip: '28379'
     latitude: 34.943077
     longitude: -79.761606
+    id: H001067-rockingham
 - id:
     bioguide: H001068
     govtrack: 412511
@@ -7404,6 +7979,7 @@
     zip: '95501'
     latitude: 40.8035929
     longitude: -124.1682054
+    id: H001068-eureka
   - address: 430 N. Franklin St.
     building: ''
     city: Fort Bragg
@@ -7415,6 +7991,7 @@
     zip: '95437'
     latitude: 39.44613289999999
     longitude: -123.8042883
+    id: H001068-fort_bragg
   - address: 206 G St.
     building: ''
     city: Petaluma
@@ -7426,6 +8003,7 @@
     zip: '94952'
     latitude: 38.2315024
     longitude: -122.6330448
+    id: H001068-petaluma
   - address: 999 Fifth Ave.
     building: ''
     city: San Rafael
@@ -7437,6 +8015,7 @@
     zip: '94901'
     latitude: 37.9738069
     longitude: -122.5267
+    id: H001068-san_rafael
   - address: 559 Low Gap Rd.
     building: ''
     city: Ukiah
@@ -7448,6 +8027,7 @@
     zip: '95482'
     latitude: 39.1598605
     longitude: -123.2154259
+    id: H001068-ukiah
 - id:
     bioguide: H001069
     govtrack: 412554
@@ -7464,6 +8044,7 @@
     zip: '58501'
     latitude: 46.80901129999999
     longitude: -100.7882597
+    id: H001069-bismarck
   - address: 40 1st Ave. West
     building: ''
     city: Dickinson
@@ -7475,6 +8056,7 @@
     zip: '58601'
     latitude: 46.8795958
     longitude: -102.786515
+    id: H001069-dickinson
   - address: 657 Second Avenue North
     building: 306 Federal Building
     city: Fargo
@@ -7486,6 +8068,7 @@
     zip: '58102'
     latitude: 46.878685
     longitude: -96.790097
+    id: H001069-fargo
   - address: 33 S. Third St.
     building: ''
     city: Grand Forks
@@ -7497,6 +8080,7 @@
     zip: '58201'
     latitude: 47.92500769999999
     longitude: -97.02952239999999
+    id: H001069-grand_forks
   - address: 100 First St.
     building: 105 Federal Building
     city: Minot
@@ -7508,6 +8092,7 @@
     zip: '58701'
     latitude: 48.2351551
     longitude: -101.2950057
+    id: H001069-minot
 - id:
     bioguide: H001071
     govtrack: 412623
@@ -7524,6 +8109,7 @@
     zip: '31061'
     latitude: 33.1204264
     longitude: -83.2592841
+    id: H001071-milledgeville
   - address: 100 Court St.
     building: ''
     city: Monroe
@@ -7535,6 +8121,7 @@
     zip: '30655'
     latitude: 33.7942004
     longitude: -83.71309769999999
+    id: H001071-monroe
   - address: 210 Railroad St.
     building: City-County Administration
     city: Thomson
@@ -7546,6 +8133,7 @@
     zip: '30824'
     latitude: 33.4671424
     longitude: -82.4986906
+    id: H001071-thomson
 - id:
     bioguide: H001072
     govtrack: 412609
@@ -7562,6 +8150,7 @@
     zip: '72032'
     latitude: 35.0868894
     longitude: -92.4381401
+    id: H001072-conway
   - address: 1501 N. University Ave.
     building: ''
     city: Little Rock
@@ -7573,6 +8162,7 @@
     zip: '72207'
     latitude: 34.76512630000001
     longitude: -92.3397715
+    id: H001072-little_rock
 - id:
     bioguide: H001073
     govtrack: 412654
@@ -7589,6 +8179,7 @@
     zip: '78840'
     latitude: 29.3705708
     longitude: -100.9202206
+    id: H001073-del_rio
   - address: 100 Monroe St.
     building: ''
     city: Eagle Pass
@@ -7600,6 +8191,7 @@
     zip: '78852'
     latitude: 28.706671
     longitude: -100.50032
+    id: H001073-eagle_pass
   - address: 17721 Rogers Ranch Parkway
     building: ''
     city: San Antonio
@@ -7611,6 +8203,7 @@
     zip: '78258'
     latitude: 29.6043724
     longitude: -98.5350201
+    id: H001073-san_antonio
   - address: One University Way
     building: Texas A&M San Antonio Patriots' Casa
     city: San Antonio
@@ -7622,6 +8215,7 @@
     zip: '78224'
     latitude: 29.3113119
     longitude: -98.52465839999999
+    id: H001073-san_antonio-1
   - address: 124 S. Horizon
     building: ''
     city: Socorro
@@ -7633,6 +8227,7 @@
     zip: '79927'
     latitude: 31.6495216
     longitude: -106.2845808
+    id: H001073-socorro
 - id:
     bioguide: H001074
     govtrack: 412703
@@ -7648,6 +8243,7 @@
     zip: '47130'
     latitude: 38.2842945
     longitude: -85.7413663
+    id: H001074-jeffersonville
 - id:
     bioguide: I000024
     govtrack: 300055
@@ -7664,6 +8260,7 @@
     zip: '73701'
     latitude: 36.3993287
     longitude: -97.8803343
+    id: I000024-enid
   - address: 215 E. Choctaw Ave.
     building: ''
     city: McAlester
@@ -7675,6 +8272,7 @@
     zip: '74501'
     latitude: 34.931573
     longitude: -95.7671124
+    id: I000024-mcalester
   - address: 1900 NW. Expressway St.
     building: ''
     city: Oklahoma City
@@ -7686,6 +8284,7 @@
     zip: '73118'
     latitude: 35.5219627
     longitude: -97.54575969999999
+    id: I000024-oklahoma_city
   - address: 1924 S. Utica Ave.
     building: ''
     city: Tulsa
@@ -7697,6 +8296,7 @@
     zip: 74104-6511
     latitude: 36.13417190000001
     longitude: -95.96760839999999
+    id: I000024-tulsa
 - id:
     bioguide: I000055
     govtrack: 400194
@@ -7713,6 +8313,7 @@
     zip: '30339'
     latitude: 33.8841172
     longitude: -84.4539174
+    id: I000055-atlanta
 - id:
     bioguide: I000056
     govtrack: 400196
@@ -7729,6 +8330,7 @@
     zip: '92629'
     latitude: 33.4795351
     longitude: -117.6970568
+    id: I000056-dana_point
   - address: 1800 Thibodo Rd.
     building: ''
     city: Vista
@@ -7740,6 +8342,7 @@
     zip: '92081'
     latitude: 33.1734619
     longitude: -117.2261545
+    id: I000056-vista
 - id:
     bioguide: J000032
     govtrack: 400199
@@ -7756,6 +8359,7 @@
     zip: '77020'
     latitude: 29.7758442
     longitude: -95.3269342
+    id: J000032-houston
   - address: 1919 Smith St.
     building: ''
     city: Houston
@@ -7767,6 +8371,7 @@
     zip: '77002'
     latitude: 29.7519042
     longitude: -95.37360579999999
+    id: J000032-houston-1
   - address: 420 W. 19th St.
     building: ''
     city: Houston
@@ -7778,6 +8383,7 @@
     zip: '77008'
     latitude: 29.8026927
     longitude: -95.4044876
+    id: J000032-houston-2
   - address: 6719 W. Montgomery
     building: ''
     city: Houston
@@ -7789,6 +8395,7 @@
     zip: '77091'
     latitude: 29.8575093
     longitude: -95.4221659
+    id: J000032-houston-3
 - id:
     bioguide: J000126
     govtrack: 400204
@@ -7805,6 +8412,7 @@
     zip: '75201'
     latitude: 32.7991061
     longitude: -96.80790139999999
+    id: J000126-dallas
 - id:
     bioguide: J000174
     govtrack: 400206
@@ -7821,6 +8429,7 @@
     zip: '75075'
     latitude: 33.0206224
     longitude: -96.7187297
+    id: J000174-plano
 - id:
     bioguide: J000255
     govtrack: 400209
@@ -7837,6 +8446,7 @@
     zip: '27858'
     latitude: 35.580699
     longitude: -77.356802
+    id: J000255-greenville
   - address: 1 Governmental Ave.
     building: ''
     city: Havelock
@@ -7848,6 +8458,7 @@
     zip: '28532'
     latitude: 34.8760387
     longitude: -76.9018802
+    id: J000255-havelock
   - address: 234 NW. Corridor Blvd.
     building: ''
     city: Jacksonville
@@ -7859,6 +8470,7 @@
     zip: '28540'
     latitude: 34.7806024
     longitude: -77.4857495
+    id: J000255-jacksonville
 - id:
     bioguide: J000288
     govtrack: 412199
@@ -7875,6 +8487,7 @@
     zip: '30035'
     latitude: 33.704214
     longitude: -84.1763731
+    id: J000288-decatur
 - id:
     bioguide: J000289
     govtrack: 412226
@@ -7891,6 +8504,7 @@
     zip: '44820'
     latitude: 40.8042672
     longitude: -82.9752194
+    id: J000289-bucyrus
   - address: 3121 W. Elm Plz.
     building: ''
     city: Lima
@@ -7902,6 +8516,7 @@
     zip: '45805'
     latitude: 40.7369756
     longitude: -84.161425
+    id: J000289-lima
   - address: 13 E. Main St.
     building: ''
     city: Norwalk
@@ -7913,6 +8528,7 @@
     zip: '44857'
     latitude: 41.2425971
     longitude: -82.6150462
+    id: J000289-norwalk
 - id:
     bioguide: J000290
     govtrack: 412284
@@ -7929,6 +8545,7 @@
     zip: '66762'
     latitude: 37.4174839
     longitude: -94.7048524
+    id: J000290-pittsburg
   - address: 3550 SW 5th Street
     building: 5th Street
     city: Topeka
@@ -7940,6 +8557,7 @@
     zip: '66606'
     latitude: 39.0608999
     longitude: -95.720894
+    id: J000290-topeka
 - id:
     bioguide: J000292
     govtrack: 412460
@@ -7956,6 +8574,7 @@
     zip: '43725'
     latitude: 40.0243891
     longitude: -81.5899869
+    id: J000292-cambridge
   - address: 202 Park Ave.
     building: ''
     city: Ironton
@@ -7967,6 +8586,7 @@
     zip: '45638'
     latitude: 38.5344281
     longitude: -82.68547079999999
+    id: J000292-ironton
   - address: 246 Front St.
     building: ''
     city: Marietta
@@ -7978,6 +8598,7 @@
     zip: '45750'
     latitude: 39.413511
     longitude: -81.45460899999999
+    id: J000292-marietta
   - address: 192 E. State St.
     building: ''
     city: Salem
@@ -7989,6 +8610,7 @@
     zip: '44460'
     latitude: 40.9010799
     longitude: -80.8561222
+    id: J000292-salem
 - id:
     bioguide: J000293
     govtrack: 412496
@@ -8005,6 +8627,7 @@
     zip: '53202'
     latitude: 43.0382241
     longitude: -87.90455999999999
+    id: J000293-milwaukee
   - address: 219 Washington Ave.
     building: ''
     city: Oshkosh
@@ -8016,6 +8639,7 @@
     zip: '54901'
     latitude: 44.0174081
     longitude: -88.5343632
+    id: J000293-oshkosh
 - id:
     bioguide: J000294
     govtrack: 412561
@@ -8032,6 +8656,7 @@
     zip: '11224'
     latitude: 40.5809199
     longitude: -73.9696891
+    id: J000294-brooklyn
   - address: 55 Hanson Pl.
     building: ''
     city: Brooklyn
@@ -8043,6 +8668,7 @@
     zip: '11217'
     latitude: 40.6856283
     longitude: -73.97577559999999
+    id: J000294-brooklyn-1
 - id:
     bioguide: J000295
     govtrack: 412566
@@ -8059,6 +8685,7 @@
     zip: '44077'
     latitude: 41.7245406
     longitude: -81.2427281
+    id: J000295-painesville
   - address: 10075 Ravenna Road
     building: Twinsburg Gov. Center
     city: Twinsburg
@@ -8070,6 +8697,7 @@
     zip: '44087'
     latitude: 41.3183054
     longitude: -81.4478297
+    id: J000295-twinsburg
 - id:
     bioguide: J000297
     govtrack: 412663
@@ -8086,6 +8714,7 @@
     zip: '25801'
     latitude: 37.778036
     longitude: -81.190697
+    id: J000297-beckley
   - address: 601 Federal St.
     building: Elizabeth Kee Federal Building
     city: Bluefield
@@ -8097,6 +8726,7 @@
     zip: '24701'
     latitude: 37.267208
     longitude: -81.2215008
+    id: J000297-bluefield
   - address: 845 Fifth Ave.
     building: ''
     city: Huntington
@@ -8108,6 +8738,7 @@
     zip: '25701'
     latitude: 38.4189915
     longitude: -82.4441521
+    id: J000297-huntington
 - id:
     bioguide: J000298
     govtrack: 412730
@@ -8123,6 +8754,7 @@
     zip: '98101'
     latitude: 47.6119653
     longitude: -122.3397313
+    id: J000298-seattle
 - id:
     bioguide: J000299
     govtrack: 412706
@@ -8138,6 +8770,7 @@
     zip: '71111'
     latitude: 32.5579513
     longitude: -93.7228425
+    id: J000299-bossier_city
 - id:
     bioguide: K000009
     govtrack: 400211
@@ -8154,6 +8787,7 @@
     zip: '44111'
     latitude: 41.4502564
     longitude: -81.8160502
+    id: K000009-cleveland
   - address: 200 W. Erie
     building: ''
     city: Lorain
@@ -8165,6 +8799,7 @@
     zip: '44052'
     latitude: 41.4685695
     longitude: -82.1792684
+    id: K000009-lorain
   - address: One Maritime Plaza
     building: ''
     city: Toledo
@@ -8176,6 +8811,7 @@
     zip: '43604'
     latitude: 41.6538759
     longitude: -83.528238
+    id: K000009-toledo
 - id:
     bioguide: K000188
     govtrack: 400218
@@ -8192,6 +8828,7 @@
     zip: '54701'
     latitude: 44.8120136
     longitude: -91.500022
+    id: K000188-eau_claire
   - address: 205 Fifth Ave.
     building: ''
     city: La Crosse
@@ -8203,6 +8840,7 @@
     zip: '54601'
     latitude: 43.8109182
     longitude: -91.24976400000001
+    id: K000188-la_crosse
 - id:
     bioguide: K000210
     govtrack: 400219
@@ -8219,6 +8857,7 @@
     zip: '11762'
     latitude: 40.6785193
     longitude: -73.4556272
+    id: K000210-massapequa_park
 - id:
     bioguide: K000362
     govtrack: 400220
@@ -8235,6 +8874,7 @@
     zip: '50010'
     latitude: 42.009659
     longitude: -93.57592199999999
+    id: K000362-ames
   - address: 723 Central Ave.
     building: ''
     city: Fort Dodge
@@ -8246,6 +8886,7 @@
     zip: '50501'
     latitude: 42.50478529999999
     longitude: -94.1875913
+    id: K000362-fort_dodge
   - address: 202-1st Street SE
     building: ''
     city: Mason City
@@ -8257,6 +8898,7 @@
     zip: '50401'
     latitude: 43.1511623
     longitude: -93.1974843
+    id: K000362-mason_city
   - address: 526 Nebraska St.
     building: ''
     city: Sioux City
@@ -8268,6 +8910,7 @@
     zip: '51101'
     latitude: 42.4962179
     longitude: -96.4032879
+    id: K000362-sioux_city
   - address: 306 Grand Ave.
     building: ''
     city: Spencer
@@ -8279,6 +8922,7 @@
     zip: '51301'
     latitude: 43.1407023
     longitude: -95.144286
+    id: K000362-spencer
 - id:
     bioguide: K000367
     govtrack: 412242
@@ -8295,6 +8939,7 @@
     zip: '55415'
     latitude: 44.9751443
     longitude: -93.2505863
+    id: K000367-minneapolis
   - address: 121 4th Street South
     building: ''
     city: Moorhead
@@ -8306,6 +8951,7 @@
     zip: '56560'
     latitude: 46.873119
     longitude: -96.774188
+    id: K000367-moorhead
   - address: 1130 1/2 7th Street NW
     building: ''
     city: Rochester
@@ -8317,6 +8963,7 @@
     zip: '55901'
     latitude: 44.0314822
     longitude: -92.479679
+    id: K000367-rochester
   - address: 820 9th Street North
     building: Olcott Plaza
     city: Virginia
@@ -8328,6 +8975,7 @@
     zip: '55792'
     latitude: 47.5302888
     longitude: -92.5465059
+    id: K000367-virginia
 - id:
     bioguide: K000375
     govtrack: 412435
@@ -8344,6 +8992,7 @@
     zip: '02601'
     latitude: 41.65029630000001
     longitude: -70.2930554
+    id: K000375-hyannis
   - address: 558 Pleasant St.
     building: ''
     city: New Bedford
@@ -8355,6 +9004,7 @@
     zip: '02740'
     latitude: 41.6344958
     longitude: -70.9266835
+    id: K000375-new_bedford
   - address: 170 Court St.
     building: ''
     city: Plymouth
@@ -8366,6 +9016,7 @@
     zip: '02360'
     latitude: 41.9636518
     longitude: -70.6753841
+    id: K000375-plymouth
 - id:
     bioguide: K000376
     govtrack: 412465
@@ -8382,6 +9033,7 @@
     zip: '16001'
     latitude: 40.8580044
     longitude: -79.8948869
+    id: K000376-butler
   - address: 208 E. Bayfront Pky.
     building: ''
     city: Erie
@@ -8393,6 +9045,7 @@
     zip: '16507'
     latitude: 42.1373875
     longitude: -80.0848493
+    id: K000376-erie
   - address: 430 Court St.
     building: Lawrence County Courthouse
     city: New Castle
@@ -8404,6 +9057,7 @@
     zip: '16101'
     latitude: 40.9991502
     longitude: -80.3392636
+    id: K000376-new_castle
   - address: 33 Chestnut Ave.
     building: ''
     city: Sharon
@@ -8415,6 +9069,7 @@
     zip: '16146'
     latitude: 41.2315486
     longitude: -80.5079773
+    id: K000376-sharon
 - id:
     bioguide: K000378
     govtrack: 412421
@@ -8431,6 +9086,7 @@
     zip: '61350'
     latitude: 41.346247
     longitude: -88.841051
+    id: K000378-ottawa
   - address: 725 N. Lyford Rd.
     building: ''
     city: Rockford
@@ -8442,6 +9098,7 @@
     zip: '61107'
     latitude: 42.2743104
     longitude: -88.96018389999999
+    id: K000378-rockford
   - address: 342 W. Walnut
     building: ''
     city: Watseka
@@ -8453,6 +9110,7 @@
     zip: '60970'
     latitude: 40.7762446
     longitude: -87.7383019
+    id: K000378-watseka
 - id:
     bioguide: K000379
     govtrack: 412543
@@ -8469,6 +9127,7 @@
     zip: '02703'
     latitude: 41.9449626
     longitude: -71.2846799
+    id: K000379-attleboro
   - address: 29 Crafts St.
     building: ''
     city: Newton
@@ -8480,6 +9139,7 @@
     zip: '02458'
     latitude: 42.3548224
     longitude: -71.1999166
+    id: K000379-newton
 - id:
     bioguide: K000380
     govtrack: 412546
@@ -8496,6 +9156,7 @@
     zip: '48502'
     latitude: 43.0133524
     longitude: -83.6871014
+    id: K000380-flint
 - id:
     bioguide: K000381
     govtrack: 412583
@@ -8512,6 +9173,7 @@
     zip: '98337'
     latitude: 47.5669568
     longitude: -122.6258917
+    id: K000381-bremerton
   - address: 332 E. 5th St.
     building: ''
     city: Port Angeles
@@ -8523,6 +9185,7 @@
     zip: '98362'
     latitude: 48.113181
     longitude: -123.431753
+    id: K000381-port_angeles
   - address: 950 Pacific Ave.
     building: ''
     city: Tacoma
@@ -8534,6 +9197,7 @@
     zip: '98402'
     latitude: 47.2535757
     longitude: -122.4390697
+    id: K000381-tacoma
 - id:
     bioguide: K000382
     govtrack: 412557
@@ -8550,6 +9214,7 @@
     zip: '03301'
     latitude: 43.2048069
     longitude: -71.5355091
+    id: K000382-concord
   - address: 33 Main St.
     building: ''
     city: Littleton
@@ -8561,6 +9226,7 @@
     zip: '03561'
     latitude: 44.3063587
     longitude: -71.7713705
+    id: K000382-littleton
   - address: 70 E. Pearl St.
     building: ''
     city: Nashua
@@ -8572,6 +9238,7 @@
     zip: '03060'
     latitude: 42.7601735
     longitude: -71.4642733
+    id: K000382-nashua
 - id:
     bioguide: K000383
     govtrack: 412545
@@ -8588,6 +9255,7 @@
     zip: '04330'
     latitude: 44.3676495
     longitude: -69.7940768
+    id: K000383-augusta
   - address: 202 Harlow St.
     building: ''
     city: Bangor
@@ -8599,6 +9267,7 @@
     zip: '04401'
     latitude: 44.8046399
     longitude: -68.7737891
+    id: K000383-bangor
   - address: 169 Academy St.
     building: ''
     city: Presque Isle
@@ -8610,6 +9279,7 @@
     zip: '04769'
     latitude: 46.6766073
     longitude: -67.9956649
+    id: K000383-presque_isle
   - address: 383 Route
     building: ''
     city: Scarborough
@@ -8621,6 +9291,7 @@
     zip: '04074'
     latitude: 43.5854463
     longitude: -70.3582263
+    id: K000383-scarborough
 - id:
     bioguide: K000384
     govtrack: 412582
@@ -8637,6 +9308,7 @@
     zip: '24210'
     latitude: 36.709042
     longitude: -81.981768
+    id: K000384-abingdon
   - address: 308 Craghead Street
     building: ''
     city: Danville
@@ -8648,6 +9320,7 @@
     zip: '24541'
     latitude: 36.5867166
     longitude: -79.38939599999999
+    id: K000384-danville
   - address: 9408 Grant Avenue
     building: ''
     city: Manassas
@@ -8659,6 +9332,7 @@
     zip: '20110'
     latitude: 38.7515843
     longitude: -77.4755912
+    id: K000384-manassas
   - address: 919 E. Main St.
     building: ''
     city: Richmond
@@ -8670,6 +9344,7 @@
     zip: '23219'
     latitude: 37.5374358
     longitude: -77.4362913
+    id: K000384-richmond
   - address: 611 S. Jefferson St.
     building: ''
     city: Roanoke
@@ -8681,6 +9356,7 @@
     zip: '24011'
     latitude: 37.268654
     longitude: -79.9408098
+    id: K000384-roanoke
   - address: 222 Central Park Ave.
     building: ''
     city: Virginia Beach
@@ -8692,6 +9368,7 @@
     zip: '23462'
     latitude: 36.842768
     longitude: -76.13327699999999
+    id: K000384-virginia_beach
 - id:
     bioguide: K000385
     govtrack: 412595
@@ -8708,6 +9385,7 @@
     zip: '60617'
     latitude: 41.7280317
     longitude: -87.55148679999999
+    id: K000385-chicago
   - address: 304 S. Indiana Ave.
     building: Kankakee City Hall
     city: Kankakee
@@ -8719,6 +9397,7 @@
     zip: '60901'
     latitude: 41.117146
     longitude: -87.861261
+    id: K000385-kankakee
   - address: 600 Holiday Plaza Dr.
     building: ''
     city: Matteson
@@ -8730,6 +9409,7 @@
     zip: '60443'
     latitude: 41.5042785
     longitude: -87.7382453
+    id: K000385-matteson
 - id:
     bioguide: K000386
     govtrack: 412649
@@ -8746,6 +9426,7 @@
     zip: '13021'
     latitude: 42.9318995
     longitude: -76.5664577
+    id: K000386-auburn
   - address: 7376 Route
     building: ''
     city: Lyons
@@ -8757,6 +9438,7 @@
     zip: '14489'
     latitude: 43.072187
     longitude: -77.03685779999999
+    id: K000386-lyons
   - address: 13 W. Oneida St.
     building: ''
     city: Oswego
@@ -8768,6 +9450,7 @@
     zip: '13126'
     latitude: 43.4554199
     longitude: -76.511258
+    id: K000386-oswego
   - address: 440 S. Warren St.
     building: ''
     city: Syracuse
@@ -8779,6 +9462,7 @@
     zip: '13202'
     latitude: 43.04611939999999
     longitude: -76.15161669999999
+    id: K000386-syracuse
 - id:
     bioguide: K000387
     govtrack: 412614
@@ -8795,6 +9479,7 @@
     zip: '93551'
     latitude: 34.6327078
     longitude: -118.1484295
+    id: K000387-palmdale
   - address: 26415 Carl Boyer Drive
     building: ''
     city: Santa Clarita
@@ -8806,6 +9491,7 @@
     zip: '91350'
     latitude: 34.4128248
     longitude: -118.5040453
+    id: K000387-santa_clarita
   - address: 1445 E. Los Angeles Ave.
     building: ''
     city: Simi Valley
@@ -8817,6 +9503,7 @@
     zip: '93065'
     latitude: 34.2722109
     longitude: -118.7716329
+    id: K000387-simi_valley
 - id:
     bioguide: K000388
     govtrack: 412673
@@ -8833,6 +9520,7 @@
     zip: '39701'
     latitude: 33.4985949
     longitude: -88.42587759999999
+    id: K000388-columbus
   - address: 4135 County Road 200
     building: ''
     city: Corinth
@@ -8844,6 +9532,7 @@
     zip: '38844'
     latitude: 34.9303984
     longitude: -88.43363889999999
+    id: K000388-corinth
   - address: 855 S. Dunn St.
     building: ''
     city: Eupora
@@ -8855,6 +9544,7 @@
     zip: '39744'
     latitude: 33.5403014
     longitude: -89.2688098
+    id: K000388-eupora
   - address: 2565 Caffey St.
     building: ''
     city: Hernando
@@ -8866,6 +9556,7 @@
     zip: '38632'
     latitude: 34.8226252
     longitude: -89.9956387
+    id: K000388-hernando
   - address: 431 W. Main St.
     building: ''
     city: Tupelo
@@ -8877,6 +9568,7 @@
     zip: '38804'
     latitude: 34.2570023
     longitude: -88.70811259999999
+    id: K000388-tupelo
 - id:
     bioguide: K000389
     govtrack: 412684
@@ -8892,6 +9584,7 @@
     zip: '95050'
     latitude: 37.3494432
     longitude: -121.9434873
+    id: K000389-santa_clara
 - id:
     bioguide: K000390
     govtrack: 412716
@@ -8905,6 +9598,7 @@
     state: NV
     suite: Suite 500
     zip: '89030'
+    id: K000390-north_las_vegas
 - id:
     bioguide: K000391
     govtrack: 412701
@@ -8920,6 +9614,7 @@
     zip: '60173'
     latitude: 42.042839
     longitude: -88.0382131
+    id: K000391-schaumburg
 - id:
     bioguide: K000392
     govtrack: 412724
@@ -8935,6 +9630,7 @@
     zip: '38024'
     latitude: 35.9688328
     longitude: -89.38456149999999
+    id: K000392-dyersburg
   - address: 406 S. Lindell St.
     building: ''
     city: Martin
@@ -8946,6 +9642,7 @@
     zip: '38237'
     latitude: 36.342528
     longitude: -88.850229
+    id: K000392-martin
   - address: 5900 Poplar Ave.
     building: ''
     city: Memphis
@@ -8957,6 +9654,7 @@
     zip: '38119'
     latitude: 35.1034459
     longitude: -89.8641093
+    id: K000392-memphis
 - id:
     bioguide: L000174
     govtrack: 300065
@@ -8973,6 +9671,7 @@
     zip: '05401'
     latitude: 44.47553140000001
     longitude: -73.21128259999999
+    id: L000174-burlington
   - address: 87 State St.
     building: ''
     city: Montpelier
@@ -8984,6 +9683,7 @@
     zip: '05602'
     latitude: 44.260997
     longitude: -72.5775843
+    id: L000174-montpelier
 - id:
     bioguide: L000263
     govtrack: 400238
@@ -9001,6 +9701,7 @@
     zip: '48066'
     latitude: 42.49556399999999
     longitude: -82.93856559999999
+    id: L000263-roseville
 - id:
     bioguide: L000287
     govtrack: 400240
@@ -9017,6 +9718,7 @@
     zip: '30303'
     latitude: 33.7568505
     longitude: -84.38859939999999
+    id: L000287-atlanta
 - id:
     bioguide: L000397
     govtrack: 400245
@@ -9033,6 +9735,7 @@
     zip: '95112'
     latitude: 37.3475248
     longitude: -121.8993988
+    id: L000397-san_jose
 - id:
     bioguide: L000480
     govtrack: 400246
@@ -9049,6 +9752,7 @@
     zip: '10956'
     latitude: 41.1497079
     longitude: -73.98993
+    id: L000480-new_city
   - address: 222 Mamaroneck Ave.
     building: ''
     city: White Plains
@@ -9060,6 +9764,7 @@
     zip: '10605'
     latitude: 41.0270474
     longitude: -73.76478879999999
+    id: L000480-white_plains
 - id:
     bioguide: L000491
     govtrack: 400247
@@ -9076,6 +9781,7 @@
     zip: '73099'
     latitude: 35.5916684
     longitude: -97.71702800000001
+    id: L000491-yukon
 - id:
     bioguide: L000551
     govtrack: 400237
@@ -9092,6 +9798,7 @@
     zip: '94501'
     latitude: 37.7667491
     longitude: -122.2422766
+    id: L000551-alameda
   - address: 1249 Marin Ave.
     building: Albany Community Center
     city: Albany
@@ -9103,6 +9810,7 @@
     zip: '94706'
     latitude: 37.8879742
     longitude: -122.2932172
+    id: L000551-albany
   - address: 1301 Clay St.
     building: ''
     city: Oakland
@@ -9114,6 +9822,7 @@
     zip: '94612'
     latitude: 37.8052016
     longitude: -122.2745116
+    id: L000551-oakland
   - address: 1470 Fruitvale Ave.
     building: ''
     city: Oakland
@@ -9125,6 +9834,7 @@
     zip: '94601'
     latitude: 37.7784791
     longitude: -122.2250837
+    id: L000551-oakland-1
   - address: 300 Estudillo Ave.
     building: Room C
     city: San Leandro
@@ -9136,6 +9846,7 @@
     zip: '94577'
     latitude: 37.7260242
     longitude: -122.1540198
+    id: L000551-san_leandro
 - id:
     bioguide: L000554
     govtrack: 400244
@@ -9152,6 +9863,7 @@
     zip: 08330-1746
     latitude: 39.451558
     longitude: -74.726674
+    id: L000554-mays_landing
 - id:
     bioguide: L000557
     govtrack: 400233
@@ -9168,6 +9880,7 @@
     zip: '06106'
     latitude: 41.7584184
     longitude: -72.6757241
+    id: L000557-hartford
 - id:
     bioguide: L000559
     govtrack: 400230
@@ -9184,6 +9897,7 @@
     zip: '02886'
     latitude: 41.6944274
     longitude: -71.4705546
+    id: L000559-warwick
 - id:
     bioguide: L000560
     govtrack: 400232
@@ -9200,6 +9914,7 @@
     zip: '98225'
     latitude: 48.7523829
     longitude: -122.4785173
+    id: L000560-bellingham
   - address: 2930 Wetmore Ave.
     building: Wall Street Building
     city: Everett
@@ -9211,6 +9926,7 @@
     zip: '98201'
     latitude: 47.9781562
     longitude: -122.2076204
+    id: L000560-everett
 - id:
     bioguide: L000562
     govtrack: 400249
@@ -9227,6 +9943,7 @@
     zip: '02210'
     latitude: 42.3455095
     longitude: -71.035511
+    id: L000562-boston
   - address: 155 W. Elm St.
     building: ''
     city: Brockton
@@ -9238,6 +9955,7 @@
     zip: '02301'
     latitude: 42.0822156
     longitude: -71.0255303
+    id: L000562-brockton
   - address: 1245 Hancock St.
     building: ''
     city: Quincy
@@ -9249,6 +9967,7 @@
     zip: '02169'
     latitude: 42.2526962
     longitude: -71.0049509
+    id: L000562-quincy
 - id:
     bioguide: L000563
     govtrack: 400630
@@ -9265,6 +9984,7 @@
     zip: '60638'
     latitude: 41.7934493
     longitude: -87.77626830000001
+    id: L000563-chicago
   - address: 222 E. 9th St.
     building: Central Square Building
     city: Lockport
@@ -9276,6 +9996,7 @@
     zip: '60441'
     latitude: 41.5895597
     longitude: -88.05500169999999
+    id: L000563-lockport
   - address: 5210 W. 95th St.
     building: ''
     city: Oak Lawn
@@ -9287,6 +10008,7 @@
     zip: '60453'
     latitude: 41.7201892
     longitude: -87.751137
+    id: L000563-oak_lawn
   - address: 14700 S. Ravinia Avenue
     building: Orland Park Village Hall
     city: Orland Park
@@ -9298,6 +10020,7 @@
     zip: '60462'
     latitude: 41.6232433
     longitude: -87.8573538
+    id: L000563-orland_park
 - id:
     bioguide: L000564
     govtrack: 412191
@@ -9314,6 +10037,7 @@
     zip: '81211'
     latitude: 38.8427855
     longitude: -106.1285992
+    id: L000564-buena_vista
   - address: 1125 Kelly Johnson Blvd.
     building: ''
     city: Colorado Springs
@@ -9325,6 +10049,7 @@
     zip: '80920'
     latitude: 38.94831500000001
     longitude: -104.807763
+    id: L000564-colorado_springs
 - id:
     bioguide: L000565
     govtrack: 412209
@@ -9341,6 +10066,7 @@
     zip: '52801'
     latitude: 41.5235231
     longitude: -90.5756888
+    id: L000565-davenport
   - address: 125 S. Dubuque St.
     building: ''
     city: Iowa City
@@ -9352,6 +10078,7 @@
     zip: '52240'
     latitude: 41.6592803
     longitude: -91.5334445
+    id: L000565-iowa_city
 - id:
     bioguide: L000566
     govtrack: 412256
@@ -9368,6 +10095,7 @@
     zip: '43402'
     latitude: 41.3891803
     longitude: -83.65120619999999
+    id: L000566-bowling_green
   - address: 101 Clinton St.
     building: ''
     city: Defiance
@@ -9379,6 +10107,7 @@
     zip: '43512'
     latitude: 41.2881704
     longitude: -84.36089869999999
+    id: L000566-defiance
   - address: 318 Dorney Plz.
     building: ''
     city: Findlay
@@ -9390,6 +10119,7 @@
     zip: '45840'
     latitude: 41.038435
     longitude: -83.6516735
+    id: L000566-findlay
 - id:
     bioguide: L000567
     govtrack: 412290
@@ -9406,6 +10136,7 @@
     zip: '08822'
     latitude: 40.5450411
     longitude: -74.8570729
+    id: L000567-flemington
   - address: 425 North Avenue East
     building: ''
     city: Westfield
@@ -9417,6 +10148,7 @@
     zip: '07090'
     latitude: 40.651448
     longitude: -74.340343
+    id: L000567-westfield
 - id:
     bioguide: L000569
     govtrack: 412292
@@ -9433,6 +10165,7 @@
     zip: '65109'
     latitude: 38.5813109
     longitude: -92.20679520000002
+    id: L000569-jefferson_city
   - address: 516 Jefferson St.
     building: ''
     city: Washington
@@ -9444,6 +10177,7 @@
     zip: '63090'
     latitude: 38.5560438
     longitude: -91.0132469
+    id: L000569-washington
   - address: 113 E. Pearce Blvd.
     building: ''
     city: Wentzville
@@ -9455,6 +10189,7 @@
     zip: '63385'
     latitude: 38.8122807
     longitude: -90.85187169999999
+    id: L000569-wentzville
 - id:
     bioguide: L000570
     govtrack: 412293
@@ -9471,6 +10206,7 @@
     zip: '87401'
     latitude: 36.7378735
     longitude: -108.2167002
+    id: L000570-farmington
   - address: 110 W. Aztec Ave.
     building: ''
     city: Gallup
@@ -9482,6 +10218,7 @@
     zip: '87301'
     latitude: 35.5265052
     longitude: -108.7413892
+    id: L000570-gallup
   - address: 903 University Ave.
     building: ''
     city: Las Vegas
@@ -9493,6 +10230,7 @@
     zip: '87701'
     latitude: 35.594789
     longitude: -105.2183489
+    id: L000570-las_vegas
   - address: 3200 Civic
     building: ''
     city: Rio Rancho
@@ -9504,6 +10242,7 @@
     zip: '87144'
     latitude: 35.3109178
     longitude: -106.6851151
+    id: L000570-rio_rancho
   - address: 1611 Lorca
     building: ''
     city: Santa Fe
@@ -9515,6 +10254,7 @@
     zip: '87505'
     latitude: 35.6605914
     longitude: -105.9630964
+    id: L000570-santa_fe
   - address: 404 W. Route 66 Blvd.
     building: ''
     city: Tucumcari
@@ -9526,6 +10266,7 @@
     zip: '88401'
     latitude: 35.1718132
     longitude: -103.7221881
+    id: L000570-tucumcari
 - id:
     bioguide: L000573
     govtrack: 412419
@@ -9542,6 +10283,7 @@
     zip: '83814'
     latitude: 47.6967966
     longitude: -116.8040784
+    id: L000573-coeur_d_alene
   - address: 313 D St.
     building: ''
     city: Lewiston
@@ -9553,6 +10295,7 @@
     zip: '83501'
     latitude: 46.422158
     longitude: -117.028638
+    id: L000573-lewiston
   - address: 33 E. Broadway Ave.
     building: ''
     city: Meridian
@@ -9564,6 +10307,7 @@
     zip: '83642'
     latitude: 43.6096586
     longitude: -116.3930485
+    id: L000573-meridian
 - id:
     bioguide: L000575
     govtrack: 412464
@@ -9580,6 +10324,7 @@
     zip: '73102'
     latitude: 35.4776534
     longitude: -97.5145337
+    id: L000575-oklahoma_city
   - address: 5810 E. Skelly Dr.
     building: The Remington Tower
     city: Tulsa
@@ -9591,6 +10336,7 @@
     zip: '74135'
     latitude: 36.1024933
     longitude: -95.91089249999999
+    id: L000575-tulsa
 - id:
     bioguide: L000576
     govtrack: 412445
@@ -9607,6 +10353,7 @@
     zip: '64804'
     latitude: 37.0555214
     longitude: -94.4831701
+    id: L000576-joplin
   - address: 3232 E. Ridgeview St.
     building: ''
     city: Springfield
@@ -9618,6 +10365,7 @@
     zip: '65804'
     latitude: 37.1590571
     longitude: -93.22940179999999
+    id: L000576-springfield
 - id:
     bioguide: L000577
     govtrack: 412495
@@ -9634,6 +10382,7 @@
     zip: '84401'
     latitude: 41.2206774
     longitude: -111.9726125
+    id: L000577-ogden
   - address: 125 S. State
     building: Wallace F. Bennett Federal Building
     city: Salt Lake City
@@ -9645,6 +10394,7 @@
     zip: '84138'
     latitude: 40.7667476
     longitude: -111.8871382
+    id: L000577-salt_lake_city
   - address: 285 W. Tabernacle
     building: ''
     city: St. George
@@ -9656,6 +10406,7 @@
     zip: '84770'
     latitude: 37.1079122
     longitude: -113.5893448
+    id: L000577-st__george
 - id:
     bioguide: L000578
     govtrack: 412510
@@ -9672,6 +10423,7 @@
     zip: '95602'
     latitude: 38.9527935
     longitude: -121.0815891
+    id: L000578-auburn
   - address: 2862 Olive Hwy.
     building: ''
     city: Oroville
@@ -9683,6 +10435,7 @@
     zip: '95966'
     latitude: 39.5034549
     longitude: -121.540378
+    id: L000578-oroville
   - address: 2885 Churn Creek Rd.
     building: ''
     city: Redding
@@ -9694,6 +10447,7 @@
     zip: '96002'
     latitude: 40.565758
     longitude: -122.351892
+    id: L000578-redding
 - id:
     bioguide: L000579
     govtrack: 412521
@@ -9710,6 +10464,7 @@
     zip: '90802'
     latitude: 33.7689325
     longitude: -118.1930229
+    id: L000579-long_beach
 - id:
     bioguide: L000580
     govtrack: 412558
@@ -9726,6 +10481,7 @@
     zip: '87102'
     latitude: 35.0833514
     longitude: -106.6521937
+    id: L000580-albuquerque
 - id:
     bioguide: L000581
     govtrack: 412638
@@ -9742,6 +10498,7 @@
     zip: '48213'
     latitude: 42.3902033
     longitude: -82.9819582
+    id: L000581-detroit
   - address: 26700 Lahser Road
     building: ''
     city: Southfield
@@ -9753,6 +10510,7 @@
     zip: '48033'
     latitude: 42.483811
     longitude: -83.25988629999999
+    id: L000581-southfield
 - id:
     bioguide: L000582
     govtrack: 412616
@@ -9769,6 +10527,7 @@
     zip: '90036'
     latitude: 34.062551
     longitude: -118.3402319
+    id: L000582-los_angeles
   - address: 1600 Rosecrans Ave.
     building: ''
     city: Manhattan Beach
@@ -9780,6 +10539,7 @@
     zip: '90266'
     latitude: 33.9015419
     longitude: -118.383875
+    id: L000582-manhattan_beach
 - id:
     bioguide: L000583
     govtrack: 412624
@@ -9796,6 +10556,7 @@
     zip: '30339'
     latitude: 33.8852658
     longitude: -84.46130289999999
+    id: L000583-atlanta
   - address: 135 W. Cherokee Ave.
     building: ''
     city: Cartersville
@@ -9807,6 +10568,7 @@
     zip: '30120'
     latitude: 34.1658228
     longitude: -84.7997815
+    id: L000583-cartersville
   - address: 9898 Highway 92
     building: ''
     city: Woodstock
@@ -9818,6 +10580,7 @@
     zip: '30188'
     latitude: 34.085747
     longitude: -84.523949
+    id: L000583-woodstock
 - id:
     bioguide: L000584
     govtrack: 412656
@@ -9834,6 +10597,7 @@
     zip: '84088'
     latitude: 40.5865883
     longitude: -111.9269136
+    id: L000584-west_jordan
 - id:
     bioguide: L000585
     govtrack: 412674
@@ -9850,6 +10614,7 @@
     zip: '61704'
     latitude: 40.5029607
     longitude: -88.9230848
+    id: L000585-bloomington
   - address: 201 W. Morgan St.
     building: ''
     city: Jacksonville
@@ -9861,6 +10626,7 @@
     zip: '62650'
     latitude: 39.7336397
     longitude: -90.22998150000001
+    id: L000585-jacksonville
   - address: 100 Monroe St.
     building: ''
     city: Peoria
@@ -9872,6 +10638,7 @@
     zip: '61602'
     latitude: 40.6949004
     longitude: -89.591743
+    id: L000585-peoria
   - address: 235 S. Sixth St.
     building: ''
     city: Springfield
@@ -9883,6 +10650,7 @@
     zip: '62701'
     latitude: 39.79957450000001
     longitude: -89.648127
+    id: L000585-springfield
 - id:
     bioguide: L000586
     govtrack: 412693
@@ -9898,6 +10666,7 @@
     zip: '32301'
     latitude: 30.4463425
     longitude: -84.28819759999999
+    id: L000586-tallahassee
 - id:
     bioguide: L000587
     govtrack: 412711
@@ -9913,6 +10682,7 @@
     zip: '55337'
     latitude: 44.7899842
     longitude: -93.23610699999999
+    id: L000587-burnsville
 - id:
     bioguide: M000087
     govtrack: 400251
@@ -9930,6 +10700,7 @@
     zip: 11102-1391
     latitude: 40.7674409
     longitude: -73.9203228
+    id: M000087-astoria
   - address: 619 Lorimer St.
     building: ''
     city: Brooklyn
@@ -9941,6 +10712,7 @@
     zip: 11211-222
     latitude: 40.7155784
     longitude: -73.94987139999999
+    id: M000087-brooklyn
   - address: 1651 3rd Ave.
     building: ''
     city: New York
@@ -9952,6 +10724,7 @@
     zip: 10128-3679
     latitude: 40.7828262
     longitude: -73.95068410000002
+    id: M000087-new_york
 - id:
     bioguide: M000133
     govtrack: 400253
@@ -9968,6 +10741,7 @@
     zip: '02203'
     latitude: 42.3613091
     longitude: -71.0593927
+    id: M000133-boston
   - address: 222 Milliken Blvd.
     building: ''
     city: Fall River
@@ -9979,6 +10753,7 @@
     zip: '02721'
     latitude: 41.6999176
     longitude: -71.15872660000001
+    id: M000133-fall_river
   - address: 1550 Main St.
     building: ''
     city: Springfield
@@ -9990,6 +10765,7 @@
     zip: '01101'
     latitude: 42.10321649999999
     longitude: -72.5929441
+    id: M000133-springfield
 - id:
     bioguide: M000303
     govtrack: 300071
@@ -10006,6 +10782,7 @@
     zip: '85016'
     latitude: 33.5085729
     longitude: -112.0337789
+    id: M000303-phoenix
   - address: 122 N. Cortez St.
     building: Suite 108
     city: Prescott
@@ -10017,6 +10794,7 @@
     zip: '86301'
     latitude: 34.5427185
     longitude: -112.4690897
+    id: M000303-prescott
   - address: 407 W. Congress St.
     building: ''
     city: Tucson
@@ -10028,6 +10806,7 @@
     zip: '85701'
     latitude: 32.2207319
     longitude: -110.9775264
+    id: M000303-tucson
 - id:
     bioguide: M000312
     govtrack: 400263
@@ -10044,6 +10823,7 @@
     zip: '01453'
     latitude: 42.5279312
     longitude: -71.7607974
+    id: M000312-leominster
   - address: 94 Pleasant St.
     building: ''
     city: Northampton
@@ -10055,6 +10835,7 @@
     zip: '01060'
     latitude: 42.3185388
     longitude: -72.6283162
+    id: M000312-northampton
   - address: 12 E. Worcester St.
     building: ''
     city: Worcester
@@ -10066,6 +10847,7 @@
     zip: '01604'
     latitude: 42.2628409
     longitude: -71.7903444
+    id: M000312-worcester
 - id:
     bioguide: M000355
     govtrack: 300072
@@ -10082,6 +10864,7 @@
     zip: '42101'
     latitude: 36.9948956
     longitude: -86.4430273
+    id: M000355-bowling_green
   - address: 1885 Dixie Hwy.
     building: ''
     city: Fort Wright
@@ -10093,6 +10876,7 @@
     zip: '41011'
     latitude: 39.0575706
     longitude: -84.542929
+    id: M000355-fort_wright
   - address: 771 Corporate Dr.
     building: ''
     city: Lexington
@@ -10104,6 +10888,7 @@
     zip: '40503'
     latitude: 38.0134107
     longitude: -84.5524557
+    id: M000355-lexington
   - address: 300 S. Main St.
     building: ''
     city: London
@@ -10115,6 +10900,7 @@
     zip: '40741'
     latitude: 37.1258183
     longitude: -84.0809548
+    id: M000355-london
   - address: 601 W. Broadway
     building: ''
     city: Louisville
@@ -10126,6 +10912,7 @@
     zip: '40202'
     latitude: 38.2469833
     longitude: -85.7624677
+    id: M000355-louisville
   - address: 100 Fountain Ave.
     building: ''
     city: Paducah
@@ -10137,6 +10924,7 @@
     zip: '42001'
     latitude: 37.07925609999999
     longitude: -88.6172508
+    id: M000355-paducah
 - id:
     bioguide: M000639
     govtrack: 400272
@@ -10153,6 +10941,7 @@
     zip: '08007'
     latitude: 39.8730588
     longitude: -75.04718439999999
+    id: M000639-barrington
   - address: One Gateway Center
     building: ''
     city: Newark
@@ -10164,6 +10953,7 @@
     zip: '07102'
     latitude: 40.7344571
     longitude: -74.1657213
+    id: M000639-newark
 - id:
     bioguide: M000934
     govtrack: 400284
@@ -10180,6 +10970,7 @@
     zip: '67601'
     latitude: 38.8728651
     longitude: -99.3296381
+    id: M000934-hays
   - address: 923 Westport Pl.
     building: ''
     city: Manhattan
@@ -10191,6 +10982,7 @@
     zip: '66502'
     latitude: 39.1928877
     longitude: -96.6064052
+    id: M000934-manhattan
   - address: 23600 College Blvd.
     building: ''
     city: Olathe
@@ -10202,6 +10994,7 @@
     zip: '66061'
     latitude: 38.927647
     longitude: -94.8584293
+    id: M000934-olathe
   - address: 306 N. Broadway
     building: ''
     city: Pittsburg
@@ -10213,6 +11006,7 @@
     zip: '66762'
     latitude: 37.4105276
     longitude: -94.7044411
+    id: M000934-pittsburg
   - address: 3450 N. Rock Rd.
     building: Building 200
     city: Wichita
@@ -10224,6 +11018,7 @@
     zip: '67226'
     latitude: 37.74581939999999
     longitude: -97.2435277
+    id: M000934-wichita
 - id:
     bioguide: M001111
     govtrack: 300076
@@ -10240,6 +11035,7 @@
     zip: '98201'
     latitude: 47.9781562
     longitude: -122.2076204
+    id: M001111-everett
   - address: 915 2nd Ave.
     building: 2988 Jackson Federal Building
     city: Seattle
@@ -10251,6 +11047,7 @@
     zip: '98174'
     latitude: 47.6045895
     longitude: -122.3354608
+    id: M001111-seattle
   - address: 10 N. Post St.
     building: ''
     city: Spokane
@@ -10262,6 +11059,7 @@
     zip: '99201'
     latitude: 47.65759629999999
     longitude: -117.4232771
+    id: M001111-spokane
   - address: 950 Pacific Ave.
     building: ''
     city: Tacoma
@@ -10273,6 +11071,7 @@
     zip: '98402'
     latitude: 47.2535757
     longitude: -122.4390697
+    id: M001111-tacoma
   - address: 1323 Officer's Row
     building: The Marshall House
     city: Vancouver
@@ -10284,6 +11083,7 @@
     zip: '98661'
     latitude: 45.6276649
     longitude: -122.657351
+    id: M001111-vancouver
   - address: 402 E. Yakima Ave.
     building: ''
     city: Yakima
@@ -10295,6 +11095,7 @@
     zip: '98901'
     latitude: 46.6030785
     longitude: -120.5008956
+    id: M001111-yakima
 - id:
     bioguide: M001137
     govtrack: 400271
@@ -10311,6 +11112,7 @@
     zip: '11692'
     latitude: 40.5908303
     longitude: -73.79661469999999
+    id: M001137-arverne
   - address: 153-01 Jamaica Ave.
     building: ''
     city: Jamaica
@@ -10323,6 +11125,7 @@
     zip: '11432'
     latitude: 40.7030995
     longitude: -73.80205
+    id: M001137-jamaica
 - id:
     bioguide: M001143
     govtrack: 400259
@@ -10339,6 +11142,7 @@
     zip: '55102'
     latitude: 44.946385
     longitude: -93.1163366
+    id: M001143-st__paul
 - id:
     bioguide: M001151
     govtrack: 400285
@@ -10355,6 +11159,7 @@
     zip: '15601'
     latitude: 40.2915719
     longitude: -79.5747616
+    id: M001151-greensburg
   - address: 504 Washington Rd.
     building: ''
     city: Pittsburgh
@@ -10366,6 +11171,7 @@
     zip: '15228'
     latitude: 40.3841253
     longitude: -80.04402069999999
+    id: M001151-pittsburgh
 - id:
     bioguide: M001153
     govtrack: 300075
@@ -10382,6 +11188,7 @@
     zip: '99501'
     latitude: 61.2171561
     longitude: -149.9043364
+    id: M001153-anchorage
   - address: 101 12th Ave.
     building: Federal Building
     city: Fairbanks
@@ -10393,6 +11200,7 @@
     zip: '99701'
     latitude: 64.8383052
     longitude: -147.7082477
+    id: M001153-fairbanks
   - address: 800 Glacier Ave.
     building: ''
     city: Juneau
@@ -10404,6 +11212,7 @@
     zip: '99801'
     latitude: 58.30033239999999
     longitude: -134.4205554
+    id: M001153-juneau
   - address: 805 Frontage Rd.
     building: ''
     city: Kenai
@@ -10415,6 +11224,7 @@
     zip: '99611'
     latitude: 60.55401089999999
     longitude: -151.2577208
+    id: M001153-kenai
   - address: 1900 First Ave.
     building: ''
     city: Ketchikan
@@ -10426,6 +11236,7 @@
     zip: '99901'
     latitude: 55.3492023
     longitude: -131.6673863
+    id: M001153-ketchikan
   - address: 851 E. Westpoint Dr.
     building: ''
     city: Wasilla
@@ -10437,6 +11248,7 @@
     zip: '99654'
     latitude: 61.5826697
     longitude: -149.4286826
+    id: M001153-wasilla
 - id:
     bioguide: M001156
     govtrack: 400644
@@ -10453,6 +11265,7 @@
     zip: '28711'
     latitude: 35.619814
     longitude: -82.3197859
+    id: M001156-black_mountain
   - address: 128 W. Main Ave.
     building: ''
     city: Gastonia
@@ -10464,6 +11277,7 @@
     zip: '28053'
     latitude: 35.2641049
     longitude: -81.1825879
+    id: M001156-gastonia
   - address: 1990 Main Ave.
     building: ''
     city: Hickory
@@ -10475,6 +11289,7 @@
     zip: '28603'
     latitude: 35.7313122
     longitude: -81.3022794
+    id: M001156-hickory
 - id:
     bioguide: M001157
     govtrack: 400654
@@ -10491,6 +11306,7 @@
     zip: '78759'
     latitude: 30.3864963
     longitude: -97.7528485
+    id: M001157-austin
   - address: 2000 S. Market St.
     building: ''
     city: Brenham
@@ -10502,6 +11318,7 @@
     zip: '77833'
     latitude: 30.1510408
     longitude: -96.3912448
+    id: M001157-brenham
   - address: 1773 Westborough Dr.
     building: Katy Commerce Center
     city: Katy
@@ -10513,6 +11330,7 @@
     zip: '77449'
     latitude: 29.7918796
     longitude: -95.7318468
+    id: M001157-katy
   - address: 990 Village Sq.
     building: Rosewood Professional Building
     city: Tomball
@@ -10524,6 +11342,7 @@
     zip: '77375'
     latitude: 30.096319
     longitude: -95.625406
+    id: M001157-tomball
 - id:
     bioguide: M001158
     govtrack: 400656
@@ -10540,6 +11359,7 @@
     zip: '75063'
     latitude: 32.9399753
     longitude: -96.95149119999999
+    id: M001158-irving
 - id:
     bioguide: M001159
     govtrack: 400659
@@ -10556,6 +11376,7 @@
     zip: '99114'
     latitude: 48.5392665
     longitude: -117.9052868
+    id: M001159-colville
   - address: 10 North Post Street
     building: ''
     city: Spokane
@@ -10565,6 +11386,7 @@
     state: WA
     suite: Suite 625
     zip: '99201'
+    id: M001159-spokane
   - address: 26 E. Main St.
     building: ''
     city: Walla Walla
@@ -10576,6 +11398,7 @@
     zip: '99362'
     latitude: 46.0668398
     longitude: -118.3382053
+    id: M001159-walla_walla
 - id:
     bioguide: M001160
     govtrack: 400661
@@ -10592,6 +11415,7 @@
     zip: '53202'
     latitude: 43.0344363
     longitude: -87.90565280000001
+    id: M001160-milwaukee
 - id:
     bioguide: M001163
     govtrack: 400663
@@ -10608,6 +11432,7 @@
     zip: '95814'
     latitude: 38.583455
     longitude: -121.4987519
+    id: M001163-sacramento
 - id:
     bioguide: M001165
     govtrack: 412190
@@ -10624,6 +11449,7 @@
     zip: '93309'
     latitude: 35.3750182
     longitude: -119.0467701
+    id: M001165-bakersfield
 - id:
     bioguide: M001166
     govtrack: 412189
@@ -10640,6 +11466,7 @@
     zip: '94531'
     latitude: 37.9662464
     longitude: -121.7741565
+    id: M001166-antioch
   - address: 2222 Grand Canal Blvd.
     building: ''
     city: Stockton
@@ -10651,6 +11478,7 @@
     zip: '95207'
     latitude: 37.9845267
     longitude: -121.3334181
+    id: M001166-stockton
 - id:
     bioguide: M001169
     govtrack: 412194
@@ -10667,6 +11495,7 @@
     zip: '06106'
     latitude: 41.7559191
     longitude: -72.6646397
+    id: M001169-hartford
 - id:
     bioguide: M001170
     govtrack: 412243
@@ -10683,6 +11512,7 @@
     zip: '63703'
     latitude: 37.3034205
     longitude: -89.52489279999999
+    id: M001170-cape_girardeau
   - address: 28 N. 8th St.
     building: ''
     city: Columbia
@@ -10694,6 +11524,7 @@
     zip: '65201'
     latitude: 38.952407
     longitude: -92.32828099999999
+    id: M001170-columbia
   - address: 4141 Pennsylvania Ave.
     building: ''
     city: Kansas City
@@ -10705,6 +11536,7 @@
     zip: '64111'
     latitude: 39.051963
     longitude: -94.590285
+    id: M001170-kansas_city
   - address: 324 Park Central West
     building: ''
     city: Springfield
@@ -10716,6 +11548,7 @@
     zip: '65806'
     latitude: 37.2087999
     longitude: -93.294102
+    id: M001170-springfield
   - address: 5850 Delmar Blvd.
     building: ''
     city: St. Louis
@@ -10727,6 +11560,7 @@
     zip: '63112'
     latitude: 38.6541742
     longitude: -90.28894330000001
+    id: M001170-st__louis
 - id:
     bioguide: M001176
     govtrack: 412325
@@ -10743,6 +11577,7 @@
     zip: '97701'
     latitude: 44.0577537
     longitude: -121.3095974
+    id: M001176-bend
   - address: 405 E. 8th Ave.
     building: ''
     city: Eugene
@@ -10754,6 +11589,7 @@
     zip: '97401'
     latitude: 44.0516985
     longitude: -123.0857882
+    id: M001176-eugene
   - address: 10 S. Bartlett St.
     building: ''
     city: Medford
@@ -10765,6 +11601,7 @@
     zip: '97501'
     latitude: 42.3266304
     longitude: -122.8712245
+    id: M001176-medford
   - address: 310 SE. Second St.
     building: ''
     city: Pendleton
@@ -10776,6 +11613,7 @@
     zip: '97801'
     latitude: 45.6721567
     longitude: -118.7845998
+    id: M001176-pendleton
   - address: 121 SW. Salmon St.
     building: ''
     city: Portland
@@ -10787,6 +11625,7 @@
     zip: '97204'
     latitude: 45.5160884
     longitude: -122.6748937
+    id: M001176-portland
   - address: 161 High St.
     building: ''
     city: Salem
@@ -10798,6 +11637,7 @@
     zip: '97301'
     latitude: 44.9389422
     longitude: -123.0380741
+    id: M001176-salem
 - id:
     bioguide: M001177
     govtrack: 412295
@@ -10814,6 +11654,7 @@
     zip: '95661'
     latitude: 38.74380590000001
     longitude: -121.2464852
+    id: M001177-roseville
 - id:
     bioguide: M001179
     govtrack: 412468
@@ -10830,6 +11671,7 @@
     zip: '18436'
     latitude: 41.400944
     longitude: -75.39838
+    id: M001179-lake_ariel
   - address: 713 Bridge St.
     building: ''
     city: Selinsgrove
@@ -10841,6 +11683,7 @@
     zip: '17870'
     latitude: 40.8115979
     longitude: -76.86333599999999
+    id: M001179-selinsgrove
   - address: 1020 Commerce Park Dr.
     building: ''
     city: Williamsport
@@ -10852,6 +11695,7 @@
     zip: '17701'
     latitude: 41.2471701
     longitude: -76.98338179999999
+    id: M001179-williamsport
 - id:
     bioguide: M001180
     govtrack: 412487
@@ -10868,6 +11712,7 @@
     zip: '26505'
     latitude: 39.6414678
     longitude: -79.962809
+    id: M001180-morgantown
   - address: 408 Market St.
     building: ''
     city: Parkersburg
@@ -10879,6 +11724,7 @@
     zip: '26101'
     latitude: 39.2653465
     longitude: -81.56126309999999
+    id: M001180-parkersburg
   - address: 1100 Main St.
     building: Horne  building
     city: Wheeling
@@ -10890,6 +11736,7 @@
     zip: '26003'
     latitude: 40.068749
     longitude: -80.723545
+    id: M001180-wheeling
 - id:
     bioguide: M001181
     govtrack: 412466
@@ -10906,6 +11753,7 @@
     zip: '19422'
     latitude: 40.16179
     longitude: -75.285038
+    id: M001181-blue_bell
   - address: 2004 Weavertown Rd.
     building: ''
     city: Douglassville
@@ -10917,6 +11765,7 @@
     zip: '19518'
     latitude: 40.298305
     longitude: -75.738629
+    id: M001181-douglassville
   - address: 500 Suplee Rd.
     building: ''
     city: Honey Brook
@@ -10928,6 +11777,7 @@
     zip: '19344'
     latitude: 40.0946908
     longitude: -75.88802799999999
+    id: M001181-honey_brook
   - address: 2 Township Dr.
     building: ''
     city: Paradise
@@ -10939,6 +11789,7 @@
     zip: '17562'
     latitude: 40.004637
     longitude: -76.109313
+    id: M001181-paradise
   - address: 940 W. Sproul Rd.
     building: ''
     city: Springfield
@@ -10950,6 +11801,7 @@
     zip: '19064'
     latitude: 39.9393688
     longitude: -75.350534
+    id: M001181-springfield
 - id:
     bioguide: M001182
     govtrack: 412474
@@ -10966,6 +11818,7 @@
     zip: '29340'
     latitude: 35.0772653
     longitude: -81.6451558
+    id: M001182-gaffney
   - address: 1456 Ebenezer Rd.
     building: ''
     city: Rock Hill
@@ -10977,6 +11830,7 @@
     zip: '29732'
     latitude: 34.951326
     longitude: -81.04208299999999
+    id: M001182-rock_hill
   - address: 531-A Oxford Drive
     building: ''
     city: Sumter
@@ -10988,6 +11842,7 @@
     zip: '29150'
     latitude: 33.9348302
     longitude: -80.3686704
+    id: M001182-sumter
 - id:
     bioguide: M001183
     govtrack: 412391
@@ -11004,6 +11859,7 @@
     zip: '25302'
     latitude: 38.3590792
     longitude: -81.6350089
+    id: M001183-charleston
   - address: 230 Adams St.
     building: ''
     city: Fairmont
@@ -11015,6 +11871,7 @@
     zip: '26554'
     latitude: 39.4846406
     longitude: -80.1429364
+    id: M001183-fairmont
   - address: 261 Aikens Ctr.
     building: ''
     city: Martinsburg
@@ -11026,6 +11883,7 @@
     zip: '25404'
     latitude: 39.486004
     longitude: -77.95891259999999
+    id: M001183-martinsburg
 - id:
     bioguide: M001184
     govtrack: 412503
@@ -11042,6 +11900,7 @@
     zip: '41101'
     latitude: 38.4791287
     longitude: -82.6379039
+    id: M001184-ashland
   - address: 541 Buttermilk Pike.
     building: ''
     city: Crescent Springs
@@ -11053,6 +11912,7 @@
     zip: '41017'
     latitude: 39.0486598
     longitude: -84.5777416
+    id: M001184-crescent_springs
   - address: 108 W. Jefferson St.
     building: ''
     city: La Grange
@@ -11064,6 +11924,7 @@
     zip: '40031'
     latitude: 38.4084825
     longitude: -85.37938489999999
+    id: M001184-la_grange
 - id:
     bioguide: M001185
     govtrack: 412562
@@ -11080,6 +11941,7 @@
     zip: '12550'
     latitude: 41.5036879
     longitude: -74.010127
+    id: M001185-newburgh
 - id:
     bioguide: M001187
     govtrack: 412552
@@ -11096,6 +11958,7 @@
     zip: '28776'
     latitude: 35.4846372
     longitude: -82.5240931
+    id: M001187-asheville
   - address: 98 E. Morgan St.
     building: Community Services Building Second Floor, Conference Room A
     city: Brevard
@@ -11107,6 +11970,7 @@
     zip: '28712'
     latitude: 35.2312324
     longitude: -82.7340135
+    id: M001187-brevard
   - address: 101 Mitchell St.
     building: Swain County Administration Building
     city: Bryson City
@@ -11118,6 +11982,7 @@
     zip: '28713'
     latitude: 35.4284337
     longitude: -83.44769629999999
+    id: M001187-bryson_city
   - address: 2 Town Sq.
     building: Downstairs Board Room
     city: Burnsville
@@ -11129,6 +11994,7 @@
     zip: '28714'
     latitude: 35.91698
     longitude: -82.300495
+    id: M001187-burnsville
   - address: 810 Acquoni Rd.
     building: Ginger Lynn Welch Building
     city: Cherokee
@@ -11140,6 +12006,7 @@
     zip: '28719'
     latitude: 35.4889529
     longitude: -83.31281460000001
+    id: M001187-cherokee
   - address: 5 W. Main St.
     building: Macon County Courthouse
     city: Franklin
@@ -11151,6 +12018,7 @@
     zip: '28734'
     latitude: 35.181994
     longitude: -83.3816781
+    id: M001187-franklin
   - address: 261 Courthouse Dr.
     building: Clay County Courthouse
     city: Hayesville
@@ -11162,6 +12030,7 @@
     zip: '28904'
     latitude: 35.041118
     longitude: -83.829076
+    id: M001187-hayesville
   - address: 200 N. Grove St.
     building: Henderson County Court House
     city: Hendersonville
@@ -11173,6 +12042,7 @@
     zip: '28792'
     latitude: 35.3159633
     longitude: -82.45688779999999
+    id: M001187-hendersonville
   - address: 2345 Morganton Blvd.
     building: Health and Human Services Bldg.
     city: Lenoir
@@ -11184,6 +12054,7 @@
     zip: '28645'
     latitude: 35.8920346
     longitude: -81.5724283
+    id: M001187-lenoir
   - address: 100 Spaulding Road
     building: McDowell County Senior Center
     city: Marion
@@ -11195,6 +12066,7 @@
     zip: '28752'
     latitude: 35.6661262
     longitude: -82.02352800000001
+    id: M001187-marion
   - address: 1 N. Main St.
     building: Madison County Courthouse
     city: Marshall
@@ -11206,6 +12078,7 @@
     zip: '28753'
     latitude: 35.7974471
     longitude: -82.68422000000001
+    id: M001187-marshall
   - address: 305 E. Union St.
     building: City of Morganton Town Hall
     city: Morganton
@@ -11217,6 +12090,7 @@
     zip: '28655'
     latitude: 35.7480974
     longitude: -81.6863355
+    id: M001187-morganton
   - address: 107 Peachtree St.
     building: Murphy Power Board
     city: Murphy
@@ -11228,6 +12102,7 @@
     zip: '28906'
     latitude: 35.0865265
     longitude: -84.0326446
+    id: M001187-murphy
   - address: 300 Schultz Cir.
     building: Avery County Sheriff's Office
     city: Newland
@@ -11239,6 +12114,7 @@
     zip: '28657'
     latitude: 36.086433
     longitude: -81.927144
+    id: M001187-newland
   - address: 12 N. Main St.
     building: Graham County Courthouse
     city: Robbinsville
@@ -11250,6 +12126,7 @@
     zip: '28771'
     latitude: 35.323017
     longitude: -83.80684699999999
+    id: M001187-robbinsville
   - address: 11 Crystal St.
     building: Mitchell Country Chamber of Commerce Building
     city: Spruce Pine
@@ -11261,6 +12138,7 @@
     zip: '28777'
     latitude: 35.91595
     longitude: -82.068939
+    id: M001187-spruce_pine
   - address: 125 Bonnie Ln.
     building: Southwestern Commission Building
     city: Sylva
@@ -11272,6 +12150,7 @@
     zip: '28779'
     latitude: 35.3514788
     longitude: -83.208622
+    id: M001187-sylva
   - address: 285 N. Main St.
     building: ''
     city: Waynesville
@@ -11283,6 +12162,7 @@
     zip: '28786'
     latitude: 35.4932599
     longitude: -82.98666940000001
+    id: M001187-waynesville
 - id:
     bioguide: M001188
     govtrack: 412560
@@ -11299,6 +12179,7 @@
     zip: '11358'
     latitude: 40.76260720000001
     longitude: -73.8062197
+    id: M001188-flushing
   - address: 118-35 Queens Blvd.
     building: ''
     city: Forest Hills
@@ -11310,6 +12191,7 @@
     zip: '11375'
     latitude: 40.7148445
     longitude: -73.8310816
+    id: M001188-forest_hills
 - id:
     bioguide: M001189
     govtrack: 412540
@@ -11326,6 +12208,7 @@
     zip: '47305'
     latitude: 40.191017
     longitude: -85.38692119999999
+    id: M001189-muncie
   - address: 50 N. 5th St.
     building: Richmond Municipal Building
     city: Richmond
@@ -11337,6 +12220,7 @@
     zip: '47374'
     latitude: 39.8300456
     longitude: -84.89590609999999
+    id: M001189-richmond
   - address: 2 Public Sq.
     building: ''
     city: Shelbyville
@@ -11348,6 +12232,7 @@
     zip: '46176'
     latitude: 39.524864
     longitude: -85.776797
+    id: M001189-shelbyville
 - id:
     bioguide: M001190
     govtrack: 412568
@@ -11364,6 +12249,7 @@
     zip: '74501'
     latitude: 34.9325288
     longitude: -95.76939100000001
+    id: M001190-mcalester
   - address: 3109 Azalea Park Dr.
     building: ''
     city: Muskogee
@@ -11375,6 +12261,7 @@
     zip: '74401'
     latitude: 35.7676771
     longitude: -95.40146519999999
+    id: M001190-muskogee
 - id:
     bioguide: M001193
     govtrack: 412643
@@ -11391,6 +12278,7 @@
     zip: '08053'
     latitude: 39.8840544
     longitude: -74.89168529999999
+    id: M001193-marlton
   - address: 33 Washington St.
     building: Township of Toms River Town Hall
     city: Toms River
@@ -11402,6 +12290,7 @@
     zip: '08753'
     latitude: 39.9526066
     longitude: -74.1967616
+    id: M001193-toms_river
 - id:
     bioguide: M001194
     govtrack: 412634
@@ -11418,6 +12307,7 @@
     zip: '49601'
     latitude: 44.2512349
     longitude: -85.4006138
+    id: M001194-cadillac
   - address: 200 E. Main St.
     building: ''
     city: Midland
@@ -11429,6 +12319,7 @@
     zip: '48640'
     latitude: 43.6125894
     longitude: -84.2447609
+    id: M001194-midland
 - id:
     bioguide: M001195
     govtrack: 412662
@@ -11445,6 +12336,7 @@
     zip: '25301'
     latitude: 38.3517371
     longitude: -81.6320052
+    id: M001195-charleston
   - address: 300 Foxcroft Ave.
     building: ''
     city: Martinsburg
@@ -11456,6 +12348,7 @@
     zip: '25401'
     latitude: 39.4607489
     longitude: -77.986887
+    id: M001195-martinsburg
 - id:
     bioguide: M001196
     govtrack: 412632
@@ -11472,6 +12365,7 @@
     zip: '01970'
     latitude: 42.5204343
     longitude: -70.8944236
+    id: M001196-salem
 - id:
     bioguide: M001197
     govtrack: 412611
@@ -11488,6 +12382,7 @@
     zip: '85635'
     latitude: 31.5533785
     longitude: -110.2663836
+    id: M001197-sierra_vista
   - address: 4400 E. Broadway Blvd.
     building: ''
     city: Tucson
@@ -11499,6 +12394,7 @@
     zip: '85711'
     latitude: 32.2209228
     longitude: -110.8978934
+    id: M001197-tucson
 - id:
     bioguide: M001198
     govtrack: 412704
@@ -11514,6 +12410,7 @@
     zip: '67401'
     latitude: 38.8403082
     longitude: -97.60774119999999
+    id: M001198-salina
 - id:
     bioguide: M001199
     govtrack: 412698
@@ -11529,6 +12426,7 @@
     zip: '34984'
     latitude: 27.2741604
     longitude: -80.3430288
+    id: M001199-port_st_lucie
   - address: 171 SW. Flager Ave.
     building: ''
     city: Stuart
@@ -11540,6 +12438,7 @@
     zip: '34994'
     latitude: 27.200589
     longitude: -80.2560599
+    id: M001199-stuart
 - id:
     bioguide: M001200
     govtrack: 412728
@@ -11559,6 +12458,7 @@
     zip: '48317'
     latitude: 42.653045
     longitude: -83.033869
+    id: M001201-shelby_township
 - id:
     bioguide: M001202
     govtrack: 412694
@@ -11574,6 +12474,7 @@
     zip: '32801'
     latitude: 28.546165
     longitude: -81.3744028
+    id: M001202-orlando
   - address: 110 W. First Street
     building: ''
     city: Sanford
@@ -11583,6 +12484,7 @@
     state: FL
     suite: Suite 210
     zip: '32771'
+    id: M001202-sanford
 - id:
     bioguide: N000002
     govtrack: 400289
@@ -11599,6 +12501,7 @@
     zip: '11219'
     latitude: 40.6298149
     longitude: -74.0100219
+    id: N000002-brooklyn
   - address: 201 Varick St.
     building: ''
     city: New York
@@ -11610,6 +12513,7 @@
     zip: '10014'
     latitude: 40.7283398
     longitude: -74.00622109999999
+    id: N000002-new_york
 - id:
     bioguide: N000015
     govtrack: 400291
@@ -11626,6 +12530,7 @@
     zip: '01201'
     latitude: 42.4521544
     longitude: -73.25534979999999
+    id: N000015-pittsfield
   - address: 300 State St.
     building: ''
     city: Springfield
@@ -11637,6 +12542,7 @@
     zip: '01105'
     latitude: 42.1049876
     longitude: -72.58316479999999
+    id: N000015-springfield
 - id:
     bioguide: N000032
     govtrack: 300078
@@ -11653,6 +12559,7 @@
     zip: '33134'
     latitude: 25.7481437
     longitude: -80.2581661
+    id: N000032-coral_gables
   - address: 3416 S. University Dr.
     building: ''
     city: Fort Lauderdale
@@ -11664,6 +12571,7 @@
     zip: '33328'
     latitude: 26.079503
     longitude: -80.25040419999999
+    id: N000032-fort_lauderdale
   - address: 2000 Main St.
     building: ''
     city: Fort Myers
@@ -11675,6 +12583,7 @@
     zip: '33901'
     latitude: 26.6412123
     longitude: -81.8719405
+    id: N000032-fort_myers
   - address: 1301 Riverplace Blvd.
     building: Riverplace Tower
     city: Jacksonville
@@ -11686,6 +12595,7 @@
     zip: '32207'
     latitude: 30.3193247
     longitude: -81.6563618
+    id: N000032-jacksonville
   - address: 225 E. Robinson St.
     building: ''
     city: Orlando
@@ -11697,6 +12607,7 @@
     zip: '32801'
     latitude: 28.546165
     longitude: -81.3744028
+    id: N000032-orlando
   - address: 111 N. Adams St.
     building: ''
     city: Tallahassee
@@ -11708,6 +12619,7 @@
     zip: '32301'
     latitude: 30.4432698
     longitude: -84.2813422
+    id: N000032-tallahassee
   - address: 801 N. Florida Ave.
     building: ''
     city: Tampa
@@ -11719,6 +12631,7 @@
     zip: '33602'
     latitude: 27.9514851
     longitude: -82.4580986
+    id: N000032-tampa
   - address: 413 Clematis St.
     building: ''
     city: West Palm Beach
@@ -11730,6 +12643,7 @@
     zip: '33401'
     latitude: 26.7135091
     longitude: -80.0544664
+    id: N000032-west_palm_beach
 - id:
     bioguide: N000127
     govtrack: 408211
@@ -11746,6 +12660,7 @@
     zip: '56401'
     latitude: 46.3559828
     longitude: -94.2018082
+    id: N000127-brainerd
   - address: 313 N. Main St.
     building: Chisago County Government Center
     city: Center City
@@ -11757,6 +12672,7 @@
     zip: '55012'
     latitude: 45.399409
     longitude: -92.822425
+    id: N000127-center_city
   - address: 316 W. Lake St.
     building: Chisholm City Hall
     city: Chisholm
@@ -11768,6 +12684,7 @@
     zip: '55719'
     latitude: 47.48962
     longitude: -92.88476399999999
+    id: N000127-chisholm
   - address: 11 E. Superior St.
     building: Duluth Technology Village
     city: Duluth
@@ -11779,6 +12696,7 @@
     zip: '55802'
     latitude: 46.7876494
     longitude: -92.0979108
+    id: N000127-duluth
 - id:
     bioguide: N000147
     govtrack: 400295
@@ -11795,6 +12713,7 @@
     zip: '20001'
     latitude: 38.9031719
     longitude: -77.00662319999999
+    id: N000147-washington
   - address: 2041 Martin Luther King Jr Ave.
     building: ''
     city: Washington
@@ -11806,6 +12725,7 @@
     zip: '20020'
     latitude: 38.8659837
     longitude: -76.9897997
+    id: N000147-washington-1
 - id:
     bioguide: N000179
     govtrack: 400290
@@ -11822,6 +12742,7 @@
     zip: '91731'
     latitude: 34.0866787
     longitude: -118.0289184
+    id: N000179-el_monte
 - id:
     bioguide: N000181
     govtrack: 400297
@@ -11838,6 +12759,7 @@
     zip: '93612'
     latitude: 36.8268342
     longitude: -119.7008959
+    id: N000181-clovis
   - address: 113 N. Church St.
     building: ''
     city: Visalia
@@ -11849,6 +12771,7 @@
     zip: '93291'
     latitude: 36.3304563
     longitude: -119.2914737
+    id: N000181-visalia
 - id:
     bioguide: N000184
     govtrack: 412475
@@ -11863,6 +12786,7 @@
     state: SD
     suite: ''
     zip: ''
+    id: N000184-
   - address: ''
     building: ''
     city: ''
@@ -11872,6 +12796,7 @@
     state: SD
     suite: ''
     zip: ''
+    id: N000184--1
   - address: 2525 W. Main St.
     building: ''
     city: Rapid City
@@ -11883,6 +12808,7 @@
     zip: '57702'
     latitude: 44.0816004
     longitude: -103.2614256
+    id: N000184-rapid_city
   - address: 300 N. Dakota Ave.
     building: ''
     city: Sioux Falls
@@ -11894,6 +12820,7 @@
     zip: '57104'
     latitude: 43.5506713
     longitude: -96.72940419999999
+    id: N000184-sioux_falls
   - address: 818 S. Broadway
     building: ''
     city: Watertown
@@ -11905,6 +12832,7 @@
     zip: '57201'
     latitude: 44.8908032
     longitude: -97.1183604
+    id: N000184-watertown
 - id:
     bioguide: N000188
     govtrack: 412606
@@ -11921,6 +12849,7 @@
     zip: '08003'
     latitude: 39.8719711
     longitude: -75.0138274
+    id: N000188-cherry_hill
 - id:
     bioguide: N000189
     govtrack: 412660
@@ -11937,6 +12866,7 @@
     zip: '99354'
     latitude: 46.3444932
     longitude: -119.2718385
+    id: N000189-richland
   - address: 402 E. Yakima Ave.
     building: ''
     city: Yakima
@@ -11948,6 +12878,7 @@
     zip: '98901'
     latitude: 46.6030785
     longitude: -120.5008956
+    id: N000189-yakima
 - id:
     bioguide: O000168
     govtrack: 412302
@@ -11964,6 +12895,7 @@
     zip: '77494'
     latitude: 29.7035409
     longitude: -95.7716839
+    id: O000168-katy
   - address: 1650 Highway 6
     building: ''
     city: Sugar Land
@@ -11975,6 +12907,7 @@
     zip: '77478'
     latitude: 29.5989855
     longitude: -95.6285772
+    id: O000168-sugar_land
 - id:
     bioguide: O000170
     govtrack: 412575
@@ -11991,6 +12924,7 @@
     zip: '79901'
     latitude: 31.759121
     longitude: -106.4890945
+    id: O000170-el_paso
 - id:
     bioguide: O000171
     govtrack: 412682
@@ -12006,6 +12940,7 @@
     zip: '85122'
     latitude: 32.8770219
     longitude: -111.7541607
+    id: O000171-casa_grande
   - address: 405 N. Beaver St.
     building: ''
     city: Flagstaff
@@ -12017,6 +12952,7 @@
     zip: '68001'
     latitude: 35.2019797
     longitude: -111.6486132
+    id: O000171-flagstaff
 - id:
     bioguide: P000034
     govtrack: 400308
@@ -12033,6 +12969,7 @@
     zip: '07740'
     latitude: 40.299971
     longitude: -73.99841099999999
+    id: P000034-long_branch
   - address: 67 Church St.
     building: ''
     city: New Brunswick
@@ -12044,6 +12981,7 @@
     zip: '08901'
     latitude: 40.4962932
     longitude: -74.4427577
+    id: P000034-new_brunswick
 - id:
     bioguide: P000096
     govtrack: 400309
@@ -12060,6 +12998,7 @@
     zip: '07631'
     latitude: 40.8946254
     longitude: -73.97540300000001
+    id: P000096-englewood
   - address: 367 Valley Brook Ave.
     building: ''
     city: Lyndhurst
@@ -12071,6 +13010,7 @@
     zip: '07071'
     latitude: 40.8126716
     longitude: -74.1243659
+    id: P000096-lyndhurst
   - address: 330 Passaic St.
     building: 1st Street
     city: Passaic
@@ -12082,6 +13022,7 @@
     zip: '07055'
     latitude: 40.8612025
     longitude: -74.12380890000001
+    id: P000096-passaic
   - address: 200 Federal Plz.
     building: Robert A. Roe Federal Building
     city: Paterson
@@ -12093,6 +13034,7 @@
     zip: '07505'
     latitude: 40.9151292
     longitude: -74.1699154
+    id: P000096-paterson
 - id:
     bioguide: P000197
     govtrack: 400314
@@ -12109,6 +13051,7 @@
     zip: '94103'
     latitude: 37.7791976
     longitude: -122.4121784
+    id: P000197-san_francisco
 - id:
     bioguide: P000258
     govtrack: 400316
@@ -12125,6 +13068,7 @@
     zip: '56501'
     latitude: 46.81886249999999
     longitude: -95.84703619999999
+    id: P000258-detroit_lakes
   - address: 1420 E. College Dr.
     building: ''
     city: Marshall
@@ -12136,6 +13080,7 @@
     zip: '56258'
     latitude: 44.447474
     longitude: -95.7610983
+    id: P000258-marshall
   - address: 100 N. First St.
     building: ''
     city: Montevideo
@@ -12147,6 +13092,7 @@
     zip: '56265'
     latitude: 44.9455663
     longitude: -95.7243254
+    id: P000258-montevideo
   - address: 230 E. 3rd St.
     building: ''
     city: Redwood Falls
@@ -12158,6 +13104,7 @@
     zip: '56283'
     latitude: 44.5395952
     longitude: -95.11752489999999
+    id: P000258-redwood_falls
   - address: 324 3rd St.
     building: ''
     city: Willmar
@@ -12169,6 +13116,7 @@
     zip: '56201'
     latitude: 45.1213299
     longitude: -95.04656659999999
+    id: P000258-willmar
 - id:
     bioguide: P000449
     govtrack: 400325
@@ -12185,6 +13133,7 @@
     zip: '45202'
     latitude: 39.0993058
     longitude: -84.5103687
+    id: P000449-cincinnati
   - address: 1240 E. 9th St.
     building: ''
     city: Cleveland
@@ -12196,6 +13145,7 @@
     zip: '44199'
     latitude: 41.50477110000001
     longitude: -81.69179849999999
+    id: P000449-cleveland
   - address: 37 W. Broad St.
     building: ''
     city: Columbus
@@ -12207,6 +13157,7 @@
     zip: '43215'
     latitude: 39.9617817
     longitude: -83.00202759999999
+    id: P000449-columbus
   - address: 420 Madison Ave.
     building: ''
     city: Toledo
@@ -12218,6 +13169,7 @@
     zip: '43604'
     latitude: 41.6518781
     longitude: -83.53530549999999
+    id: P000449-toledo
 - id:
     bioguide: P000523
     govtrack: 400326
@@ -12234,6 +13186,7 @@
     zip: '27514'
     latitude: 35.9455529
     longitude: -79.0136236
+    id: P000523-chapel_hill
   - address: 301 Green St.
     building: ''
     city: Fayetteville
@@ -12245,6 +13198,7 @@
     zip: '28301'
     latitude: 35.0561773
     longitude: -78.8778276
+    id: P000523-fayetteville
   - address: 436 N. Harrington St.
     building: ''
     city: Raleigh
@@ -12256,6 +13210,7 @@
     zip: '27603'
     latitude: 35.7866594
     longitude: -78.6442275
+    id: P000523-raleigh
 - id:
     bioguide: P000588
     govtrack: 400313
@@ -12272,6 +13227,7 @@
     zip: '88310'
     latitude: 32.9009617
     longitude: -105.9594593
+    id: P000588-alamogordo
   - address: 200 E. Broadway
     building: ''
     city: Hobbs
@@ -12283,6 +13239,7 @@
     zip: '88240'
     latitude: 32.7011128
     longitude: -103.1343786
+    id: P000588-hobbs
   - address: 570 N. Telshor Blvd.
     building: ''
     city: Las Cruces
@@ -12294,6 +13251,7 @@
     zip: '88011'
     latitude: 32.3269491
     longitude: -106.7539714
+    id: P000588-las_cruces
   - address: 3445 Lambros
     building: ''
     city: Los Lunas
@@ -12305,6 +13263,7 @@
     zip: '87031'
     latitude: 34.8060071
     longitude: -106.7010011
+    id: P000588-los_lunas
   - address: 1717 W. 2nd St.
     building: ''
     city: Roswell
@@ -12316,6 +13275,7 @@
     zip: '88201'
     latitude: 33.3945215
     longitude: -104.549276
+    id: P000588-roswell
   - address: 111 School Of Mines Rd.
     building: ''
     city: Socorro
@@ -12327,6 +13287,7 @@
     zip: '87801'
     latitude: 34.0581218
     longitude: -106.8939734
+    id: P000588-socorro
 - id:
     bioguide: P000591
     govtrack: 400626
@@ -12343,6 +13304,7 @@
     zip: '30075'
     latitude: 34.0137629
     longitude: -84.3601582
+    id: P000591-roswell
 - id:
     bioguide: P000592
     govtrack: 400652
@@ -12359,6 +13321,7 @@
     zip: '77339'
     latitude: 30.0514781
     longitude: -95.2297545
+    id: P000592-kingwood
 - id:
     bioguide: P000593
     govtrack: 412192
@@ -12375,6 +13338,7 @@
     zip: '80215'
     latitude: 39.7390492
     longitude: -105.1404146
+    id: P000593-lakewood
 - id:
     bioguide: P000594
     govtrack: 412303
@@ -12391,6 +13355,7 @@
     zip: '55344'
     latitude: 44.8576705
     longitude: -93.42194769999999
+    id: P000594-eden_prairie
 - id:
     bioguide: P000595
     govtrack: 412305
@@ -12407,6 +13372,7 @@
     zip: '48226'
     latitude: 42.3311478
     longitude: -83.0532168
+    id: P000595-detroit
   - address: 110 Michigan St.
     building: Gerald R. Ford Federal Building
     city: Grand Rapids
@@ -12418,6 +13384,7 @@
     zip: '49503'
     latitude: 42.96997460000001
     longitude: -85.67097419999999
+    id: P000595-grand_rapids
   - address: 124 W. Allegan St.
     building: ''
     city: Lansing
@@ -12429,6 +13396,7 @@
     zip: '48933'
     latitude: 42.73289279999999
     longitude: -84.553479
+    id: P000595-lansing
   - address: 857 W. Washington St.
     building: ''
     city: Marquette
@@ -12440,6 +13408,7 @@
     zip: '49855'
     latitude: 46.545668
     longitude: -87.413111
+    id: P000595-marquette
   - address: 407 6th St.
     building: ''
     city: Rochester
@@ -12451,6 +13420,7 @@
     zip: '48307'
     latitude: 42.682816
     longitude: -83.137692
+    id: P000595-rochester
   - address: 515 N. Washington Ave.
     building: ''
     city: Saginaw
@@ -12462,6 +13432,7 @@
     zip: '48607'
     latitude: 43.438206
     longitude: -83.93773879999999
+    id: P000595-saginaw
   - address: 818 Red Dr.
     building: ''
     city: Traverse City
@@ -12473,6 +13444,7 @@
     zip: '49684'
     latitude: 44.7556947
     longitude: -85.64489909999999
+    id: P000595-traverse_city
 - id:
     bioguide: P000597
     govtrack: 412307
@@ -12489,6 +13461,7 @@
     zip: '04101'
     latitude: 43.651525
     longitude: -70.25413499999999
+    id: P000597-portland
   - address: 1 Silver St.
     building: ''
     city: Waterville
@@ -12500,6 +13473,7 @@
     zip: '04901'
     latitude: 44.5488273
     longitude: -69.62960439999999
+    id: P000597-waterville
 - id:
     bioguide: P000598
     govtrack: 412308
@@ -12516,6 +13490,7 @@
     zip: '80302'
     latitude: 40.0179538
     longitude: -105.2732497
+    id: P000598-boulder
   - address: 1220 S. College Ave.
     building: ''
     city: Fort Collins
@@ -12527,6 +13502,7 @@
     zip: '80525'
     latitude: 40.57130730000001
     longitude: -105.0765266
+    id: P000598-fort_collins
   - address: P.O. Box 1453
     building: ''
     city: Frisco
@@ -12538,6 +13514,7 @@
     zip: '80443'
     latitude: 39.5744309
     longitude: -106.0975203
+    id: P000598-frisco
 - id:
     bioguide: P000599
     govtrack: 412309
@@ -12554,6 +13531,7 @@
     zip: '32940'
     latitude: 28.246385
     longitude: -80.736905
+    id: P000599-melbourne
 - id:
     bioguide: P000601
     govtrack: 412443
@@ -12570,6 +13548,7 @@
     zip: '39532'
     latitude: 30.44543689999999
     longitude: -88.9391931
+    id: P000601-biloxi
   - address: 641 Main St.
     building: ''
     city: Hattiesburg
@@ -12581,6 +13560,7 @@
     zip: '39401'
     latitude: 31.32792959999999
     longitude: -89.2911006
+    id: P000601-hattiesburg
   - address: 3118 Pascagoula St.
     building: ''
     city: Pascagoula
@@ -12592,6 +13572,7 @@
     zip: '39567'
     latitude: 30.3652731
     longitude: -88.5554872
+    id: P000601-pascagoula
 - id:
     bioguide: P000602
     govtrack: 412431
@@ -12608,6 +13589,7 @@
     zip: '67207'
     latitude: 37.6780708
     longitude: -97.24667099999999
+    id: P000602-wichita
 - id:
     bioguide: P000603
     govtrack: 412492
@@ -12624,6 +13606,7 @@
     zip: '42101'
     latitude: 36.991545
     longitude: -86.44277609999999
+    id: P000603-bowling_green
   - address: 541 Buttermilk Park.
     building: ''
     city: Crescent Springs
@@ -12635,6 +13618,7 @@
     zip: '41017'
     latitude: 39.0486598
     longitude: -84.5777416
+    id: P000603-crescent_springs
   - address: 1100 S. Main St.
     building: ''
     city: Hopkinsville
@@ -12646,6 +13630,7 @@
     zip: '42240'
     latitude: 36.864579
     longitude: -87.48951339999999
+    id: P000603-hopkinsville
   - address: 771 Corporate Dr.
     building: ''
     city: Lexington
@@ -12657,6 +13642,7 @@
     zip: '40503'
     latitude: 38.0134107
     longitude: -84.5524557
+    id: P000603-lexington
   - address: 600 Dr Mlk Jr Pl.
     building: ''
     city: Louisville
@@ -12668,6 +13654,7 @@
     zip: '40202'
     latitude: 38.2486082
     longitude: -85.7622452
+    id: P000603-louisville
   - address: 423 Frederica St.
     building: ''
     city: Owensboro
@@ -12679,6 +13666,7 @@
     zip: '42301'
     latitude: 37.771803
     longitude: -87.11289599999999
+    id: P000603-owensboro
 - id:
     bioguide: P000604
     govtrack: 412506
@@ -12695,6 +13683,7 @@
     zip: '07205'
     latitude: 40.70234809999999
     longitude: -74.228127
+    id: P000604-hillside
   - address: 253 Martin Luther King Dr.
     building: ''
     city: Jersey City
@@ -12706,6 +13695,7 @@
     zip: '07305'
     latitude: 40.7077679
     longitude: -74.0826434
+    id: P000604-jersey_city
   - address: 60 Nelson Pl.
     building: LeRoy F. Smith, Jr. Public Safety Building
     city: Newark
@@ -12717,6 +13707,7 @@
     zip: '07102'
     latitude: 40.73821
     longitude: -74.182222
+    id: P000604-newark
 - id:
     bioguide: P000605
     govtrack: 412569
@@ -12733,6 +13724,7 @@
     zip: '17325'
     latitude: 39.830579
     longitude: -77.232111
+    id: P000605-gettysburg
   - address: 730 N. Front St.
     building: ''
     city: Wormleysburg
@@ -12744,6 +13736,7 @@
     zip: '17043'
     latitude: 40.26472500000001
     longitude: -76.909221
+    id: P000605-wormleysburg
   - address: 2209 E. Market St.
     building: ''
     city: York
@@ -12755,6 +13748,7 @@
     zip: '17402'
     latitude: 39.9740449
     longitude: -76.684116
+    id: P000605-york
 - id:
     bioguide: P000606
     govtrack: 412551
@@ -12771,6 +13765,7 @@
     zip: '28210'
     latitude: 35.150247
     longitude: -80.8405681
+    id: P000606-charlotte
   - address: 225 Ray Ave.
     building: ''
     city: Fayetteville
@@ -12782,6 +13777,7 @@
     zip: '28301'
     latitude: 35.0558587
     longitude: -78.88181449999999
+    id: P000606-fayetteville
   - address: 100 W. Jefferson St.
     building: ''
     city: Monroe
@@ -12793,6 +13789,7 @@
     zip: '28112'
     latitude: 34.983558
     longitude: -80.549678
+    id: P000606-monroe
 - id:
     bioguide: P000607
     govtrack: 412585
@@ -12809,6 +13806,7 @@
     zip: '53511'
     latitude: 42.49752240000001
     longitude: -89.03699309999999
+    id: P000607-beloit
   - address: 10 E. Doty St.
     building: ''
     city: Madison
@@ -12820,6 +13818,7 @@
     zip: '53703'
     latitude: 43.0737508
     longitude: -89.3816999
+    id: P000607-madison
 - id:
     bioguide: P000608
     govtrack: 412523
@@ -12836,6 +13835,7 @@
     zip: '92121'
     latitude: 32.8755637
     longitude: -117.2121916
+    id: P000608-san_diego
 - id:
     bioguide: P000609
     govtrack: 412608
@@ -12852,6 +13852,7 @@
     zip: '35243'
     latitude: 33.4391291
     longitude: -86.7225137
+    id: P000609-birmingham
   - address: 703 2nd Ave North
     building: ''
     city: Clanton
@@ -12863,6 +13864,7 @@
     zip: '35045'
     latitude: 32.8389716
     longitude: -86.63128739999999
+    id: P000609-clanton
   - address: 202 3rd Ave.
     building: Oneonta City Hall
     city: Oneonta
@@ -12874,6 +13876,7 @@
     zip: '35121'
     latitude: 33.946179
     longitude: -86.4770578
+    id: P000609-oneonta
 - id:
     bioguide: P000610
     govtrack: 412659
@@ -12890,6 +13893,7 @@
     zip: '00840'
     latitude: 17.712475
     longitude: -64.882701
+    id: P000610-frederiksted
   - address: 9100 Port Of Sale Mall
     building: ''
     city: St. Thomas
@@ -12901,6 +13905,7 @@
     zip: '00802'
     latitude: 18.334264
     longitude: -64.919169
+    id: P000610-st__thomas
 - id:
     bioguide: P000611
     govtrack: 412633
@@ -12917,6 +13922,7 @@
     zip: '04401'
     latitude: 44.8022714
     longitude: -68.7701151
+    id: P000611-bangor
   - address: 179 Lisbon St.
     building: ''
     city: Lewiston
@@ -12928,6 +13934,7 @@
     zip: '04240'
     latitude: 44.0955387
     longitude: -70.21693599999999
+    id: P000611-lewiston
   - address: 631 Main St.
     building: ''
     city: Presque Isle
@@ -12939,6 +13946,7 @@
     zip: '04769'
     latitude: 46.6856865
     longitude: -68.0143427
+    id: P000611-presque_isle
 - id:
     bioguide: P000612
     govtrack: 412666
@@ -12955,6 +13963,7 @@
     zip: '30303'
     latitude: 33.7589915
     longitude: -84.38681749999999
+    id: P000612-atlanta
 - id:
     bioguide: P000613
     govtrack: 412685
@@ -12970,6 +13979,7 @@
     zip: '93901'
     latitude: 36.6737182
     longitude: -121.6575375
+    id: P000613-salinas
   - address: 701 Ocean St.
     building: ''
     city: Santa Cruz
@@ -12981,6 +13991,7 @@
     zip: '95060'
     latitude: 36.9778501
     longitude: -122.0226351
+    id: P000613-santa_cruz
 - id:
     bioguide: Q000023
     govtrack: 412331
@@ -12997,6 +14008,7 @@
     zip: '60641'
     latitude: 41.9600352
     longitude: -87.7536327
+    id: Q000023-chicago
   - address: 3223 N. Sheffield Ave.
     building: ''
     city: Chicago
@@ -13008,6 +14020,7 @@
     zip: '60657'
     latitude: 41.94076279999999
     longitude: -87.6538984
+    id: Q000023-chicago-1
 - id:
     bioguide: R000122
     govtrack: 300081
@@ -13024,6 +14037,7 @@
     zip: '02920'
     latitude: 41.7566184
     longitude: -71.4607281
+    id: R000122-cranston
   - address: One Exchange Terrace
     building: U.S. District Courthouse
     city: Providence
@@ -13035,6 +14049,7 @@
     zip: 02903-1744
     latitude: 41.8262057
     longitude: -71.4109836
+    id: R000122-providence
 - id:
     bioguide: R000307
     govtrack: 300083
@@ -13051,6 +14066,7 @@
     zip: '67801'
     latitude: 37.7540807
     longitude: -100.0164714
+    id: R000307-dodge_city
   - address: 11900 College Boulevard
     building: ''
     city: Overland Park
@@ -13062,6 +14078,7 @@
     zip: '66210'
     latitude: 38.9280229
     longitude: -94.7243276
+    id: R000307-overland_park
   - address: 444 SE. Quincy
     building: Frank Carlson Federal Bldg.
     city: Topeka
@@ -13073,6 +14090,7 @@
     zip: '66683'
     latitude: 39.0529221
     longitude: -95.670288
+    id: R000307-topeka
   - address: 125 N. Market St.
     building: ''
     city: Wichita
@@ -13084,6 +14102,7 @@
     zip: '67202'
     latitude: 37.6870978
     longitude: -97.3372521
+    id: R000307-wichita
 - id:
     bioguide: R000395
     govtrack: 400340
@@ -13100,6 +14119,7 @@
     zip: '41701'
     latitude: 37.3598755
     longitude: -83.2591463
+    id: R000395-hazard
   - address: 110 Resource Ct.
     building: ''
     city: Prestonsburg
@@ -13111,6 +14131,7 @@
     zip: '41653'
     latitude: 37.6921145
     longitude: -82.7793413
+    id: R000395-prestonsburg
   - address: 551 Clifty St.
     building: ''
     city: Somerset
@@ -13122,6 +14143,7 @@
     zip: '42503'
     latitude: 37.0976576
     longitude: -84.6167349
+    id: R000395-somerset
 - id:
     bioguide: R000409
     govtrack: 400343
@@ -13138,6 +14160,7 @@
     zip: '92648'
     latitude: 33.6576447
     longitude: -118.0019705
+    id: R000409-huntington_beach
 - id:
     bioguide: R000435
     govtrack: 400344
@@ -13154,6 +14177,7 @@
     zip: '33155'
     latitude: 25.7238346
     longitude: -80.31280819999999
+    id: R000435-miami
 - id:
     bioguide: R000486
     govtrack: 400347
@@ -13170,6 +14194,7 @@
     zip: '90040'
     latitude: 34.0062357
     longitude: -118.1519972
+    id: R000486-commerce
 - id:
     bioguide: R000487
     govtrack: 400348
@@ -13186,6 +14211,7 @@
     zip: '92821'
     latitude: 33.918593
     longitude: -117.9008
+    id: R000487-brea
   - address: 1380 S. Fullerton Rd.
     building: ''
     city: Rowland Heights
@@ -13197,6 +14223,7 @@
     zip: '91748'
     latitude: 33.9932263
     longitude: -117.9015236
+    id: R000487-rowland_heights
 - id:
     bioguide: R000515
     govtrack: 400350
@@ -13213,6 +14240,7 @@
     zip: 60643-4732
     latitude: 41.6793889
     longitude: -87.6811963
+    id: R000515-chicago
 - id:
     bioguide: R000570
     govtrack: 400351
@@ -13229,6 +14257,7 @@
     zip: '53545'
     latitude: 42.6822267
     longitude: -89.0222192
+    id: R000570-janesville
   - address: 5031 7th Ave.
     building: ''
     city: Kenosha
@@ -13240,6 +14269,7 @@
     zip: '53140'
     latitude: 42.5902918
     longitude: -87.8204312
+    id: R000570-kenosha
   - address: 216 6th St.
     building: ''
     city: Racine
@@ -13251,6 +14281,7 @@
     zip: '53403'
     latitude: 42.7267777
     longitude: -87.7835892
+    id: R000570-racine
 - id:
     bioguide: R000575
     govtrack: 400341
@@ -13267,6 +14298,7 @@
     zip: '36201'
     latitude: 33.6595488
     longitude: -85.8294458
+    id: R000575-anniston
   - address: 701 Avenue A
     building: G.W. Andrews Federal Building
     city: Opelika
@@ -13278,6 +14310,7 @@
     zip: '36801'
     latitude: 32.6481909
     longitude: -85.3772489
+    id: R000575-opelika
 - id:
     bioguide: R000576
     govtrack: 400349
@@ -13294,6 +14327,7 @@
     zip: '21093'
     latitude: 39.454911
     longitude: -76.640205
+    id: R000576-timonium
 - id:
     bioguide: R000577
     govtrack: 400352
@@ -13310,6 +14344,7 @@
     zip: '44310'
     latitude: 41.099949
     longitude: -81.478217
+    id: R000577-akron
   - address: 197 W. Market St.
     building: ''
     city: Warren
@@ -13321,6 +14356,7 @@
     zip: '44481'
     latitude: 41.235888
     longitude: -80.819818
+    id: R000577-warren
   - address: 241 W. Federal St.
     building: ''
     city: Youngstown
@@ -13332,6 +14368,7 @@
     zip: '44503'
     latitude: 41.1012396
     longitude: -80.6529585
+    id: R000577-youngstown
 - id:
     bioguide: R000578
     govtrack: 400660
@@ -13348,6 +14385,7 @@
     zip: '98029'
     latitude: 47.5512594
     longitude: -122.0388342
+    id: R000578-issaquah
   - address: 5 S. Wenatchee Ave.
     building: ''
     city: Wenatchee
@@ -13359,6 +14397,7 @@
     zip: '98801'
     latitude: 47.4246335
     longitude: -120.3111242
+    id: R000578-wenatchee
 - id:
     bioguide: R000580
     govtrack: 412202
@@ -13375,6 +14414,7 @@
     zip: '60010'
     latitude: 42.153073
     longitude: -88.13739799999999
+    id: R000580-barrington
   - address: 2700 W. International Dr.
     building: ''
     city: West Chicago
@@ -13386,6 +14426,7 @@
     zip: '60185'
     latitude: 41.90679720000001
     longitude: -88.2549054
+    id: R000580-west_chicago
 - id:
     bioguide: R000582
     govtrack: 412310
@@ -13402,6 +14443,7 @@
     zip: '37660'
     latitude: 36.5481252
     longitude: -82.56324289999999
+    id: R000582-kingsport
   - address: 1609 Walters State Cc Dr.
     building: ''
     city: Morristown
@@ -13413,6 +14455,7 @@
     zip: '37813'
     latitude: 36.2043221
     longitude: -83.26019269999999
+    id: R000582-morristown
 - id:
     bioguide: R000583
     govtrack: 412311
@@ -13429,6 +14472,7 @@
     zip: '34972'
     latitude: 27.2453409
     longitude: -80.8328056
+    id: R000583-okeechobee
   - address: 226 Taylor St.
     building: ''
     city: Punta Gorda
@@ -13440,6 +14484,7 @@
     zip: '33950'
     latitude: 26.934659
     longitude: -82.05022
+    id: R000583-punta_gorda
   - address: 4507 George Blvd.
     building: ''
     city: Sebring
@@ -13451,6 +14496,7 @@
     zip: '33875'
     latitude: 27.441374
     longitude: -81.419974
+    id: R000583-sebring
 - id:
     bioguide: R000584
     govtrack: 412322
@@ -13467,6 +14513,7 @@
     zip: '83702'
     latitude: 43.618145
     longitude: -116.2024194
+    id: R000584-boise
   - address: 610 Hubbard
     building: ''
     city: Coeur d'Alene
@@ -13478,6 +14525,7 @@
     zip: '83814'
     latitude: 47.6826921
     longitude: -116.7920799
+    id: R000584-coeur_d_alene
   - address: 901 Pier View Dr.
     building: ''
     city: Idaho Falls
@@ -13489,6 +14537,7 @@
     zip: '83402'
     latitude: 43.4836745
     longitude: -112.0514001
+    id: R000584-idaho_falls
   - address: 313 D St.
     building: ''
     city: Lewiston
@@ -13500,6 +14549,7 @@
     zip: '83501'
     latitude: 46.422158
     longitude: -117.028638
+    id: R000584-lewiston
   - address: 275 S. 5th Ave.
     building: ''
     city: Pocatello
@@ -13511,6 +14561,7 @@
     zip: '83201'
     latitude: 42.8649373
     longitude: -112.4428822
+    id: R000584-pocatello
   - address: 1411 Falls Avenue East
     building: ''
     city: Twin Falls
@@ -13522,6 +14573,7 @@
     zip: '83301'
     latitude: 42.5785998
     longitude: -114.456626
+    id: R000584-twin_falls
 - id:
     bioguide: R000585
     govtrack: 412393
@@ -13538,6 +14590,7 @@
     zip: '14830'
     latitude: 42.1441654
     longitude: -77.0580681
+    id: R000585-corning
   - address: 433 Exchange St.
     building: ''
     city: Geneva
@@ -13549,6 +14602,7 @@
     zip: '14456'
     latitude: 42.868166
     longitude: -76.980885
+    id: R000585-geneva
   - address: 401 E. State St.
     building: ''
     city: Ithaca
@@ -13560,6 +14614,7 @@
     zip: '14850'
     latitude: 42.4391794
     longitude: -76.4933839
+    id: R000585-ithaca
   - address: 2 E. 2nd St.
     building: ''
     city: Jamestown
@@ -13571,6 +14626,7 @@
     zip: '14701'
     latitude: 42.0953958
     longitude: -79.2406941
+    id: R000585-jamestown
   - address: One Bluebird Square
     building: ''
     city: Olean
@@ -13582,6 +14638,7 @@
     zip: '14760'
     latitude: 42.07941
     longitude: -78.43005699999999
+    id: R000585-olean
 - id:
     bioguide: R000586
     govtrack: 412462
@@ -13598,6 +14655,7 @@
     zip: '44129'
     latitude: 41.36695
     longitude: -81.733102
+    id: R000586-parma
   - address: 1 Park Center Dr.
     building: ''
     city: Wadsworth
@@ -13609,6 +14667,7 @@
     zip: '44281'
     latitude: 41.0476588
     longitude: -81.72764149999999
+    id: R000586-wadsworth
 - id:
     bioguide: R000588
     govtrack: 412432
@@ -13625,6 +14684,7 @@
     zip: '70802'
     latitude: 30.4340407
     longitude: -91.17866599999999
+    id: R000588-baton_rouge
   - address: 200 Derbigny St.
     building: ''
     city: Gretna
@@ -13636,6 +14696,7 @@
     zip: '70053'
     latitude: 29.9160227
     longitude: -90.06773629999999
+    id: R000588-gretna
   - address: 2021 Lakeshore Dr.
     building: ''
     city: New Orleans
@@ -13647,6 +14708,7 @@
     zip: '70122'
     latitude: 30.0318171
     longitude: -90.06439449999999
+    id: R000588-new_orleans
 - id:
     bioguide: R000591
     govtrack: 412394
@@ -13663,6 +14725,7 @@
     zip: '36420'
     latitude: 31.3084109
     longitude: -86.4756474
+    id: R000591-andalusia
   - address: 217 Graceland Dr.
     building: ''
     city: Dothan
@@ -13674,6 +14737,7 @@
     zip: '36305'
     latitude: 31.232517
     longitude: -85.452038
+    id: R000591-dothan
   - address: 401 Adams Ave.
     building: ''
     city: Montgomery
@@ -13685,6 +14749,7 @@
     zip: '36104'
     latitude: 32.3749292
     longitude: -86.3029162
+    id: R000591-montgomery
 - id:
     bioguide: R000592
     govtrack: 412426
@@ -13702,6 +14767,7 @@
     zip: '46122'
     latitude: 39.7570534
     longitude: -86.52317409999999
+    id: R000592-danville
   - address: 230 N. 4th St.
     building: ''
     city: Lafayette
@@ -13713,6 +14779,7 @@
     zip: '47901'
     latitude: 40.4197836
     longitude: -86.8936818
+    id: R000592-lafayette
 - id:
     bioguide: R000593
     govtrack: 412411
@@ -13729,6 +14796,7 @@
     zip: '33813'
     latitude: 27.969113
     longitude: -81.962131
+    id: R000593-lakeland
   - address: 110 W. Reynolds St.
     building: ''
     city: Plant City
@@ -13740,6 +14808,7 @@
     zip: '33563'
     latitude: 28.0162609
     longitude: -82.1238742
+    id: R000593-plant_city
 - id:
     bioguide: R000595
     govtrack: 412491
@@ -13756,6 +14825,7 @@
     zip: '33166'
     latitude: 25.8109245
     longitude: -80.3361915
+    id: R000595-doral
   - address: 1650 Prudential Dr.
     building: ''
     city: Jacksonville
@@ -13767,6 +14837,7 @@
     zip: '32207'
     latitude: 30.3159309
     longitude: -81.65249709999999
+    id: R000595-jacksonville
   - address: 3299 E. Tamiami Trl.
     building: ''
     city: Naples
@@ -13778,6 +14849,7 @@
     zip: '34112'
     latitude: 26.1270603
     longitude: -81.7664209
+    id: R000595-naples
   - address: 201 S. Orange Ave.
     building: ''
     city: Orlando
@@ -13789,6 +14861,7 @@
     zip: '32801'
     latitude: 28.5400755
     longitude: -81.3780508
+    id: R000595-orlando
   - address: 4580 Pga Blvd.
     building: ''
     city: Palm Beach Gardens
@@ -13800,6 +14873,7 @@
     zip: '33418'
     latitude: 26.8380427
     longitude: -80.11140940000001
+    id: R000595-palm_beach_gardens
   - address: 700 S. Palafox St.
     building: ''
     city: Pensacola
@@ -13811,6 +14885,7 @@
     zip: '32502'
     latitude: 30.405605
     longitude: -87.213161
+    id: R000595-pensacola
   - address: 402 S. Monroe St.
     building: ''
     city: Tallahassee
@@ -13822,6 +14897,7 @@
     zip: '32399'
     latitude: 30.438114
     longitude: -84.281289
+    id: R000595-tallahassee
   - address: 5201 W. Kennedy Blvd.
     building: ''
     city: Tampa
@@ -13833,6 +14909,7 @@
     zip: '33609'
     latitude: 27.945205
     longitude: -82.5314559
+    id: R000595-tampa
 - id:
     bioguide: R000597
     govtrack: 412572
@@ -13849,6 +14926,7 @@
     zip: '29501'
     latitude: 34.1959092
     longitude: -79.8017864
+    id: R000597-florence
   - address: 2411 N. Oak St.
     building: ''
     city: Myrtle Beach
@@ -13860,6 +14938,7 @@
     zip: '29577'
     latitude: 33.7081253
     longitude: -78.87212720000001
+    id: R000597-myrtle_beach
 - id:
     bioguide: R000598
     govtrack: 412570
@@ -13876,6 +14955,7 @@
     zip: '15009'
     latitude: 40.69418
     longitude: -80.304699
+    id: R000598-beaver
   - address: 110 Franklin St.
     building: ''
     city: Johnstown
@@ -13887,6 +14967,7 @@
     zip: '15901'
     latitude: 40.3261659
     longitude: -78.9175992
+    id: R000598-johnstown
   - address: 6000 Babcock Blvd.
     building: ''
     city: Pittsburgh
@@ -13898,6 +14979,7 @@
     zip: '15237'
     latitude: 40.55107470000001
     longitude: -80.0239448
+    id: R000598-pittsburgh
 - id:
     bioguide: R000599
     govtrack: 412519
@@ -13914,6 +14996,7 @@
     zip: '92543'
     latitude: 33.7472608
     longitude: -116.9677534
+    id: R000599-hemet
   - address: 43875 Washington Street
     building: ''
     city: Palm Desert
@@ -13925,6 +15008,7 @@
     zip: '92211'
     latitude: 33.7302529
     longitude: -116.3043432
+    id: R000599-palm_desert
 - id:
     bioguide: R000600
     govtrack: 412664
@@ -13941,6 +15025,7 @@
     zip: '96799'
     latitude: -14.2775712
     longitude: -170.6899787
+    id: R000600-pago_pago
 - id:
     bioguide: R000601
     govtrack: 412653
@@ -13957,6 +15042,7 @@
     zip: '75032'
     latitude: 32.8672397
     longitude: -96.4424884
+    id: R000601-rockwall
   - address: 100 W. Houston St.
     building: ''
     city: Sherman
@@ -13968,6 +15054,7 @@
     zip: '75090'
     latitude: 33.6358717
     longitude: -96.60972439999999
+    id: R000601-sherman
   - address: 2600 N. Robison Rd.
     building: Texarkana College – Health Science Building
     city: Texarkana
@@ -13979,6 +15066,7 @@
     zip: '75599'
     latitude: 33.4436958
     longitude: -94.0802978
+    id: R000601-texarkana
 - id:
     bioguide: R000602
     govtrack: 412647
@@ -13995,6 +15083,7 @@
     zip: '11530'
     latitude: 40.7258629
     longitude: -73.63281649999999
+    id: R000602-garden_city
 - id:
     bioguide: R000603
     govtrack: 412641
@@ -14011,6 +15100,7 @@
     zip: '28422'
     latitude: 34.0583353
     longitude: -78.16267719999999
+    id: R000603-bolivia
   - address: 4001 Us Hwy.
     building: ''
     city: Four Oaks
@@ -14022,6 +15112,7 @@
     zip: '27524'
     latitude: 35.46515
     longitude: -78.387203
+    id: R000603-four_oaks
   - address: 230 Government Center Dr.
     building: ''
     city: Wilmington
@@ -14033,6 +15124,7 @@
     zip: '28403'
     latitude: 34.2415626
     longitude: -77.8669625
+    id: R000603-wilmington
 - id:
     bioguide: R000604
     govtrack: 412650
@@ -14049,6 +15141,7 @@
     zip: '73115'
     latitude: 35.4345678
     longitude: -97.43374179999999
+    id: R000604-del_city
 - id:
     bioguide: R000605
     govtrack: 412669
@@ -14065,6 +15158,7 @@
     zip: '57401'
     latitude: 45.45953249999999
     longitude: -98.48834950000001
+    id: R000605-aberdeen
   - address: 111 W. Capitol Ave.
     building: ''
     city: Pierre
@@ -14076,6 +15170,7 @@
     zip: '57501'
     latitude: 44.36917280000001
     longitude: -100.35182
+    id: R000605-pierre
   - address: 1313 W. Main St.
     building: ''
     city: Rapid City
@@ -14087,6 +15182,7 @@
     zip: '57701'
     latitude: 44.0818193
     longitude: -103.2403111
+    id: R000605-rapid_city
   - address: 320 N. Main Ave.
     building: ''
     city: Sioux Falls
@@ -14098,6 +15194,7 @@
     zip: '57104'
     latitude: 43.5506861
     longitude: -96.7279008
+    id: R000605-sioux_falls
 - id:
     bioguide: R000606
     govtrack: 412708
@@ -14113,6 +15210,7 @@
     zip: '20850'
     latitude: 39.083791
     longitude: -77.1481645
+    id: R000606-rockville
 - id:
     bioguide: R000607
     govtrack: 412699
@@ -14128,6 +15226,7 @@
     zip: '33990'
     latitude: 26.6320987
     longitude: -81.9561391
+    id: R000607-cape_coral
   - address: 3299 Tamiami Trail East
     building: ''
     city: Naples
@@ -14139,6 +15238,7 @@
     zip: '34112'
     latitude: 26.1270603
     longitude: -81.7664209
+    id: R000607-naples
 - id:
     bioguide: R000608
     govtrack: 412715
@@ -14154,6 +15254,7 @@
     zip: '89123'
     latitude: 36.0278905
     longitude: -115.1159622
+    id: R000608-las_vegas
 - id:
     bioguide: R000609
     govtrack: 412692
@@ -14169,6 +15270,7 @@
     zip: '32216'
     latitude: 30.2539737
     longitude: -81.5959646
+    id: R000609-jacksonville
 - id:
     bioguide: S000033
     govtrack: 400357
@@ -14185,6 +15287,7 @@
     zip: '05401'
     latitude: 44.4802081
     longitude: -73.21307019999999
+    id: S000033-burlington
   - address: 357 Western Ave.
     building: ''
     city: St. Johnsbury
@@ -14196,6 +15299,7 @@
     zip: '05819'
     latitude: 44.4173546
     longitude: -72.02646469999999
+    id: S000033-st__johnsbury
 - id:
     bioguide: S000051
     govtrack: 400607
@@ -14212,6 +15316,7 @@
     zip: '29902'
     latitude: 32.43928700000001
     longitude: -80.67047199999999
+    id: S000051-beaufort
   - address: 530 Johnnie Dodds Blvd.
     building: ''
     city: Mount Pleasant
@@ -14223,6 +15328,7 @@
     zip: 29464-3083
     latitude: 32.8060149
     longitude: -79.88793369999999
+    id: S000051-mount_pleasant
 - id:
     bioguide: S000148
     govtrack: 300087
@@ -14239,6 +15345,7 @@
     zip: '14614'
     latitude: 43.1576631
     longitude: -77.613515
+    id: S000148-rochester
   - address: 1 Clinton Ave.
     building: Leo O'Brien Building
     city: Albany
@@ -14250,6 +15357,7 @@
     zip: '12207'
     latitude: 42.65513869999999
     longitude: -73.749201
+    id: S000148-albany
   - address: 15 Henry St.
     building: Room. 100 A-F
     city: Binghamton
@@ -14261,6 +15369,7 @@
     zip: '13901'
     latitude: 42.1008749
     longitude: -75.9123579
+    id: S000148-binghamton
   - address: 130 S. Elmwood Ave.
     building: ''
     city: Buffalo
@@ -14272,6 +15381,7 @@
     zip: '14202'
     latitude: 42.88902849999999
     longitude: -78.87954189999999
+    id: S000148-buffalo
   - address: 145 Pine Lawn Rd.
     building: ''
     city: Melville
@@ -14283,6 +15393,7 @@
     zip: '11747'
     latitude: 40.7708436
     longitude: -73.40787569999999
+    id: S000148-melville
   - address: 780 Third Ave.
     building: ''
     city: New York
@@ -14294,6 +15405,7 @@
     zip: '10017'
     latitude: 40.7550353
     longitude: -73.97185879999999
+    id: S000148-new_york
   - address: One Park Place
     building: ''
     city: Peekskill
@@ -14305,6 +15417,7 @@
     zip: '10566'
     latitude: 41.29051020000001
     longitude: -73.91672969999999
+    id: S000148-peekskill
   - address: 100 S. Clinton St.
     building: ''
     city: Syracuse
@@ -14316,6 +15429,7 @@
     zip: '13261'
     latitude: 43.0501042
     longitude: -76.1543204
+    id: S000148-syracuse
 - id:
     bioguide: S000185
     govtrack: 400364
@@ -14332,6 +15446,7 @@
     zip: '23607'
     latitude: 36.9788711
     longitude: -76.4304902
+    id: S000185-newport_news
 - id:
     bioguide: S000244
     govtrack: 400365
@@ -14348,6 +15463,7 @@
     zip: 53005-6294
     latitude: 43.0288605
     longitude: -88.0784599
+    id: S000244-brookfield
 - id:
     bioguide: S000248
     govtrack: 400366
@@ -14364,6 +15480,7 @@
     zip: '10474'
     latitude: 40.81678230000001
     longitude: -73.8906744
+    id: S000248-bronx
 - id:
     bioguide: S000250
     govtrack: 400367
@@ -14380,6 +15497,7 @@
     zip: 75251-1229
     latitude: 32.9222738
     longitude: -96.7703002
+    id: S000250-dallas
 - id:
     bioguide: S000320
     govtrack: 300089
@@ -14396,6 +15514,7 @@
     zip: '35203'
     latitude: 33.517386
     longitude: -86.810488
+    id: S000320-birmingham
   - address: 1000 Glenn Hearn Blvd.
     building: ''
     city: Huntsville
@@ -14407,6 +15526,7 @@
     zip: '35824'
     latitude: 34.6471339
     longitude: -86.77460219999999
+    id: S000320-huntsville
   - address: 113 St Joseph St.
     building: U.S. Federal Courthouse
     city: Mobile
@@ -14418,6 +15538,7 @@
     zip: '36602'
     latitude: 30.6938886
     longitude: -88.0431615
+    id: S000320-mobile
   - address: 15 Lee St.
     building: FMJ Federal Courthouse
     city: Montgomery
@@ -14429,6 +15550,7 @@
     zip: '36104'
     latitude: 32.3752753
     longitude: -86.3089916
+    id: S000320-montgomery
   - address: 2005 University Blvd.
     building: ''
     city: Tuscaloosa
@@ -14440,6 +15562,7 @@
     zip: '35401'
     latitude: 33.21019640000001
     longitude: -87.5631689
+    id: S000320-tuscaloosa
 - id:
     bioguide: S000344
     govtrack: 400371
@@ -14456,6 +15579,7 @@
     zip: '91403'
     latitude: 34.1615172
     longitude: -118.4483015
+    id: S000344-sherman_oaks
 - id:
     bioguide: S000364
     govtrack: 400373
@@ -14473,6 +15597,7 @@
     zip: '61832'
     latitude: 40.1282688
     longitude: -87.62999789999999
+    id: S000364-danville
   - address: 101 N. 4th St.
     building: ''
     city: Effingham
@@ -14484,6 +15609,7 @@
     zip: '62401'
     latitude: 39.1216874
     longitude: -88.5424005
+    id: S000364-effingham
   - address: 110 E. Locust St.
     building: ''
     city: Harrisburg
@@ -14495,6 +15621,7 @@
     zip: '62946'
     latitude: 37.739086
     longitude: -88.539304
+    id: S000364-harrisburg
   - address: 15 Professional Park Dr.
     building: ''
     city: Maryville
@@ -14506,6 +15633,7 @@
     zip: '62062'
     latitude: 38.737077
     longitude: -89.95489859999999
+    id: S000364-maryville
 - id:
     bioguide: S000480
     govtrack: 400378
@@ -14522,6 +15650,7 @@
     zip: '14614'
     latitude: 43.1576631
     longitude: -77.613515
+    id: S000480-rochester
 - id:
     bioguide: S000510
     govtrack: 400379
@@ -14538,6 +15667,7 @@
     zip: '98007'
     latitude: 47.6035492
     longitude: -122.1313916
+    id: S000510-bellevue
   - address: 34200 1st Way S.
     building: Federal Way Library
     city: Federal Way
@@ -14549,6 +15679,7 @@
     zip: '98003'
     latitude: 47.2945815
     longitude: -122.3317517
+    id: S000510-federal_way
   - address: 212 2nd Ave.
     building: Kent Regional Library
     city: Kent
@@ -14560,6 +15691,7 @@
     zip: '98032'
     latitude: 47.3826063
     longitude: -122.2342107
+    id: S000510-kent
   - address: 4400 88th Ave.
     building: Mercer Island Library
     city: Mercer Island
@@ -14571,6 +15703,7 @@
     zip: '98040'
     latitude: 47.5669511
     longitude: -122.2211918
+    id: S000510-mercer_island
   - address: 15 S. Grady Way.
     building: 101 Evergreen Building
     city: Renton
@@ -14582,6 +15715,7 @@
     zip: '98057'
     latitude: 47.469273
     longitude: -122.2153306
+    id: S000510-renton
   - address: 7058 32nd Ave.
     building: ''
     city: Seattle
@@ -14593,6 +15727,7 @@
     zip: '98118'
     latitude: 47.5392077
     longitude: -122.2904189
+    id: S000510-seattle
   - address: 2821 Beacon Ave.
     building: ''
     city: Seattle
@@ -14604,6 +15739,7 @@
     zip: '98144'
     latitude: 47.5779906
     longitude: -122.3114032
+    id: S000510-seattle-1
   - address: 700 Dearborn Pl.
     building: The Good Will Industries
     city: Seattle
@@ -14615,6 +15751,7 @@
     zip: '98144'
     latitude: 47.59627
     longitude: -122.3121966
+    id: S000510-seattle-2
 - id:
     bioguide: S000522
     govtrack: 400380
@@ -14631,6 +15768,7 @@
     zip: '07728'
     latitude: 40.2402775
     longitude: -74.30812019999999
+    id: S000522-freehold
   - address: 4573 S. Broad St.
     building: ''
     city: Hamilton
@@ -14642,6 +15780,7 @@
     zip: '08620'
     latitude: 40.178635
     longitude: -74.67184200000001
+    id: S000522-hamilton
   - address: 405 Route 539
     building: ''
     city: Plumsted
@@ -14653,6 +15792,7 @@
     zip: '08514'
     latitude: 40.1027135
     longitude: -74.5068462
+    id: S000522-plumsted
 - id:
     bioguide: S000583
     govtrack: 400381
@@ -14669,6 +15809,7 @@
     zip: '78741'
     latitude: 30.2347045
     longitude: -97.7394965
+    id: S000583-austin
   - address: 301 Junction Hwy.
     building: ''
     city: Kerrville
@@ -14680,6 +15821,7 @@
     zip: '78028'
     latitude: 30.05402969999999
     longitude: -99.15075189999999
+    id: S000583-kerrville
   - address: 1100 NE Loop 410
     building: ''
     city: San Antonio
@@ -14691,6 +15833,7 @@
     zip: '78209'
     latitude: 29.5152972
     longitude: -98.45390929999999
+    id: S000583-san_antonio
 - id:
     bioguide: S000770
     govtrack: 300093
@@ -14707,6 +15850,7 @@
     zip: '48226'
     latitude: 42.3307555
     longitude: -83.048152
+    id: S000770-detroit
   - address: 221 W. Lake Lansing Rd.
     building: ''
     city: East Lansing
@@ -14718,6 +15862,7 @@
     zip: '48823'
     latitude: 42.757677
     longitude: -84.48539199999999
+    id: S000770-east_lansing
   - address: 432 N. Saginaw St.
     building: ''
     city: Flint
@@ -14729,6 +15874,7 @@
     zip: '48502'
     latitude: 43.0201574
     longitude: -83.69306720000002
+    id: S000770-flint
   - address: 3280 E. Beltline Ct.
     building: ''
     city: Grand Rapids
@@ -14740,6 +15886,7 @@
     zip: '49525'
     latitude: 43.037652
     longitude: -85.588081
+    id: S000770-grand_rapids
   - address: 1901 W. Ridge
     building: ''
     city: Marquette
@@ -14751,6 +15898,7 @@
     zip: '49855'
     latitude: 46.5484343
     longitude: -87.4269822
+    id: S000770-marquette
   - address: 3335 S. Airport Road West
     building: ''
     city: Traverse City
@@ -14762,6 +15910,7 @@
     zip: '49684'
     latitude: 44.7222478
     longitude: -85.642375
+    id: S000770-traverse_city
 - id:
     bioguide: S001141
     govtrack: 300088
@@ -14778,6 +15927,7 @@
     zip: '35203'
     latitude: 33.5173384
     longitude: -86.8102366
+    id: S001141-birmingham
   - address: 100 W. Troy St.
     building: ''
     city: Dothan
@@ -14789,6 +15939,7 @@
     zip: '36303'
     latitude: 31.225401
     longitude: -85.392611
+    id: S001141-dothan
   - address: 200 Clinton Ave.
     building: Regions Center
     city: Huntsville
@@ -14800,6 +15951,7 @@
     zip: '35801'
     latitude: 34.7307435
     longitude: -86.5882087
+    id: S001141-huntsville
   - address: 41 West I-65 Service Road North
     building: BB&T
     city: Mobile
@@ -14811,6 +15963,7 @@
     zip: '36608'
     latitude: 30.690756
     longitude: -88.12684589999999
+    id: S001141-mobile
   - address: 1 Church St.
     building: ''
     city: Montgomery
@@ -14822,6 +15975,7 @@
     zip: '36104'
     latitude: 32.3743211
     longitude: -86.3099386
+    id: S001141-montgomery
 - id:
     bioguide: S001145
     govtrack: 400360
@@ -14838,6 +15992,7 @@
     zip: '60025'
     latitude: 42.0884495
     longitude: -87.8103273
+    id: S001145-glenview
   - address: 5533 N. Broadway
     building: ''
     city: Chicago
@@ -14849,6 +16004,7 @@
     zip: '60640'
     latitude: 41.9827237
     longitude: -87.6595983
+    id: S001145-chicago
   - address: 820 Davis St.
     building: ''
     city: Evanston
@@ -14860,6 +16016,7 @@
     zip: '60201'
     latitude: 42.0466618
     longitude: -87.6829625
+    id: S001145-evanston
 - id:
     bioguide: S001148
     govtrack: 400376
@@ -14876,6 +16033,7 @@
     zip: '83702'
     latitude: 43.6174275
     longitude: -116.2020512
+    id: S001148-boise
   - address: 410 Memorial Dr.
     building: ''
     city: Idaho Falls
@@ -14887,6 +16045,7 @@
     zip: '83402'
     latitude: 43.4936265
     longitude: -112.0425928
+    id: S001148-idaho_falls
   - address: 275 S. 5th Ave.
     building: ''
     city: Pocatello
@@ -14898,6 +16057,7 @@
     zip: '83201'
     latitude: 42.8649373
     longitude: -112.4428822
+    id: S001148-pocatello
   - address: 1341 Fillmore St.
     building: ''
     city: Twin Falls
@@ -14909,6 +16069,7 @@
     zip: '83301'
     latitude: 42.585699
     longitude: -114.465532
+    id: S001148-twin_falls
 - id:
     bioguide: S001150
     govtrack: 400361
@@ -14925,6 +16086,7 @@
     zip: '91502'
     latitude: 34.1815906
     longitude: -118.3083786
+    id: S001150-burbank
   - address: 5500 Hollywood Blvd.
     building: ''
     city: Los Angeles
@@ -14936,6 +16098,7 @@
     zip: '90028'
     latitude: 34.1014609
     longitude: -118.3095706
+    id: S001150-los_angeles
 - id:
     bioguide: S001154
     govtrack: 409888
@@ -14952,6 +16115,7 @@
     zip: '17201'
     latitude: 39.9372928
     longitude: -77.6608204
+    id: S001154-chambersburg
   - address: 310 Penn St.
     building: ''
     city: Hollidaysburg
@@ -14963,6 +16127,7 @@
     zip: '16648'
     latitude: 40.4298492
     longitude: -78.3900594
+    id: S001154-hollidaysburg
   - address: 827 Water St.
     building: ''
     city: Indiana
@@ -14974,6 +16139,7 @@
     zip: '15701'
     latitude: 40.62454049999999
     longitude: -79.15521269999999
+    id: S001154-indiana
 - id:
     bioguide: S001156
     govtrack: 400355
@@ -14990,6 +16156,7 @@
     zip: '90650'
     latitude: 33.9163272
     longitude: -118.0663246
+    id: S001156-norwalk
 - id:
     bioguide: S001157
     govtrack: 400363
@@ -15006,6 +16173,7 @@
     zip: '30236'
     latitude: 33.5257191
     longitude: -84.3547213
+    id: S001157-jonesboro
   - address: 888 Concord Rd.
     building: ''
     city: Smyrna
@@ -15017,6 +16185,7 @@
     zip: '30080'
     latitude: 33.874631
     longitude: -84.5279704
+    id: S001157-smyrna
 - id:
     bioguide: S001165
     govtrack: 412186
@@ -15033,6 +16202,7 @@
     zip: '07201'
     latitude: 40.6662148
     longitude: -74.1968162
+    id: S001165-elizabeth
   - address: 257 Cornelison Ave.
     building: ''
     city: Jersey City
@@ -15044,6 +16214,7 @@
     zip: '07302'
     latitude: 40.7248331
     longitude: -74.0607631
+    id: S001165-jersey_city
   - address: 5500 Palisade Ave.
     building: ''
     city: West New York
@@ -15055,6 +16226,7 @@
     zip: '07093'
     latitude: 40.7850274
     longitude: -74.0161301
+    id: S001165-west_new_york
 - id:
     bioguide: S001168
     govtrack: 412212
@@ -15071,6 +16243,7 @@
     zip: '21401'
     latitude: 38.9793786
     longitude: -76.4949839
+    id: S001168-annapolis
   - address: 14906 Old Columbia Pike
     building: Marilyn J. Praisner Community Recreation Center
     city: Burtonsville
@@ -15082,6 +16255,7 @@
     zip: '20866'
     latitude: 39.102063
     longitude: -76.941686
+    id: S001168-burtonsville
   - address: 600 Baltimore Ave.
     building: ''
     city: Towson
@@ -15093,6 +16267,7 @@
     zip: '21204'
     latitude: 39.4023248
     longitude: -76.6073615
+    id: S001168-towson
 - id:
     bioguide: S001170
     govtrack: 412219
@@ -15109,6 +16284,7 @@
     zip: '03820'
     latitude: 43.205869
     longitude: -70.8756835
+    id: S001170-dover
 - id:
     bioguide: S001172
     govtrack: 412217
@@ -15125,6 +16301,7 @@
     zip: '68803'
     latitude: 40.91689849999999
     longitude: -98.35834179999999
+    id: S001172-grand_island
   - address: 416 Valley View Dr.
     building: ''
     city: Scottsbluff
@@ -15136,6 +16313,7 @@
     zip: '69361'
     latitude: 41.8785841
     longitude: -103.6569419
+    id: S001172-scottsbluff
 - id:
     bioguide: S001175
     govtrack: 412259
@@ -15152,6 +16330,7 @@
     zip: '94402'
     latitude: 37.5496382
     longitude: -122.3167359
+    id: S001175-san_mateo
 - id:
     bioguide: S001176
     govtrack: 412261
@@ -15168,6 +16347,7 @@
     zip: '70401'
     latitude: 30.517849
     longitude: -90.47894529999999
+    id: S001176-hammond
   - address: 8026 Main St.
     building: ''
     city: Houma
@@ -15179,6 +16359,7 @@
     zip: '70360'
     latitude: 29.5979361
     longitude: -90.71805719999999
+    id: S001176-houma
   - address: 21454 Koop Drive
     building: ''
     city: Mandeville
@@ -15190,6 +16371,7 @@
     zip: '70471'
     latitude: 30.4172835
     longitude: -90.0434162
+    id: S001176-mandeville
   - address: 110 Veterans Blvd.
     building: ''
     city: Metairie
@@ -15201,6 +16383,7 @@
     zip: '70005'
     latitude: 29.9992548
     longitude: -90.1242066
+    id: S001176-metairie
 - id:
     bioguide: S001177
     govtrack: 412312
@@ -15215,6 +16398,7 @@
     state: MP
     suite: P.O. Box 1361
     zip: '96951'
+    id: S001177-rota
   - address: ''
     building: ''
     city: Saipan
@@ -15224,6 +16408,7 @@
     state: MP
     suite: P.O. Box 504879
     zip: '96950'
+    id: S001177-saipan
   - address: ''
     building: ''
     city: Tinian
@@ -15233,6 +16418,7 @@
     state: MP
     suite: PO Box 520394
     zip: '96952'
+    id: S001177-tinian
 - id:
     bioguide: S001180
     govtrack: 412315
@@ -15249,6 +16435,7 @@
     zip: '97045'
     latitude: 45.3571432
     longitude: -122.6070483
+    id: S001180-oregon_city
   - address: 530 Center St.
     building: ''
     city: Salem
@@ -15260,6 +16447,7 @@
     zip: '97301'
     latitude: 44.94254830000001
     longitude: -123.0352226
+    id: S001180-salem
 - id:
     bioguide: S001181
     govtrack: 412323
@@ -15276,6 +16464,7 @@
     zip: '03570'
     latitude: 44.4781896
     longitude: -71.1708276
+    id: S001181-berlin
   - address: 50 Opera House Sq.
     building: ''
     city: Claremont
@@ -15287,6 +16476,7 @@
     zip: '03743'
     latitude: 43.3727196
     longitude: -72.3373946
+    id: S001181-claremont
   - address: 340 Central Ave.
     building: ''
     city: Dover
@@ -15298,6 +16488,7 @@
     zip: '03820'
     latitude: 43.1952108
     longitude: -70.8748699
+    id: S001181-dover
   - address: 12 Gilbo Ave.
     building: ''
     city: Keene
@@ -15309,6 +16500,7 @@
     zip: '03431'
     latitude: 42.9323699
     longitude: -72.2794587
+    id: S001181-keene
   - address: 2 Wall St.
     building: ''
     city: Manchester
@@ -15320,6 +16512,7 @@
     zip: '03101'
     latitude: 42.9940731
     longitude: -71.46386679999999
+    id: S001181-manchester
   - address: 60 Main St.
     building: ''
     city: Nashua
@@ -15331,6 +16524,7 @@
     zip: '03060'
     latitude: 42.7633363
     longitude: -71.4659542
+    id: S001181-nashua
 - id:
     bioguide: S001183
     govtrack: 412399
@@ -15347,6 +16541,7 @@
     zip: '85260'
     latitude: 33.5830028
     longitude: -111.9081262
+    id: S001183-scottsdale
 - id:
     bioguide: S001184
     govtrack: 412471
@@ -15363,6 +16558,7 @@
     zip: '29201'
     latitude: 34.0021846
     longitude: -81.031595
+    id: S001184-columbia
   - address: 104 S. Main St.
     building: ''
     city: Greenville
@@ -15374,6 +16570,7 @@
     zip: '29601'
     latitude: 34.849407
     longitude: -82.40024
+    id: S001184-greenville
   - address: 2500 City Hall Ln.
     building: ''
     city: North Charleston
@@ -15385,6 +16582,7 @@
     zip: '29406'
     latitude: 32.8769943
     longitude: -80.0121928
+    id: S001184-north_charleston
 - id:
     bioguide: S001185
     govtrack: 412396
@@ -15401,6 +16599,7 @@
     zip: '36701'
     latitude: 32.4071252
     longitude: -87.0214629
+    id: S001185-selma
   - address: Two 20th Street North
     building: ''
     city: Birmingham
@@ -15412,6 +16611,7 @@
     zip: '35203'
     latitude: 33.5132889
     longitude: -86.80582559999999
+    id: S001185-birmingham
   - address: 101 S. Lawrence St.
     building: Courthouse
     city: Montgomery
@@ -15423,6 +16623,7 @@
     zip: '36104'
     latitude: 32.3759486
     longitude: -86.3054822
+    id: S001185-montgomery
   - address: 2501 7th St.
     building: ''
     city: Tuscaloosa
@@ -15434,6 +16635,7 @@
     zip: '35401'
     latitude: 33.2071459
     longitude: -87.56926
+    id: S001185-tuscaloosa
 - id:
     bioguide: S001187
     govtrack: 412461
@@ -15450,6 +16652,7 @@
     zip: '43026'
     latitude: 40.0297127
     longitude: -83.150804
+    id: S001187-hilliard
   - address: 123 S. Broad St.
     building: ''
     city: Lancaster
@@ -15461,6 +16664,7 @@
     zip: '43130'
     latitude: 39.7128643
     longitude: -82.60229059999999
+    id: S001187-lancaster
   - address: 69 N. South St.
     building: ''
     city: Wilmington
@@ -15472,6 +16676,7 @@
     zip: '45177'
     latitude: 39.4462521
     longitude: -83.8288317
+    id: S001187-wilmington
 - id:
     bioguide: S001189
     govtrack: 412417
@@ -15488,6 +16693,7 @@
     zip: '31794'
     latitude: 31.4548661
     longitude: -83.5107367
+    id: S001189-tifton
   - address: 230 Margie Dr.
     building: ''
     city: Warner Robins
@@ -15499,6 +16705,7 @@
     zip: '31088'
     latitude: 32.6144617
     longitude: -83.6893055
+    id: S001189-warner_robins
 - id:
     bioguide: S001190
     govtrack: 412534
@@ -15515,6 +16722,7 @@
     zip: '60069'
     latitude: 42.1964098
     longitude: -87.9362154
+    id: S001190-lincolnshire
 - id:
     bioguide: S001191
     govtrack: 412509
@@ -15531,6 +16739,7 @@
     zip: '85018'
     latitude: 33.481675
     longitude: -111.9874218
+    id: S001191-phoenix
 - id:
     bioguide: S001192
     govtrack: 412581
@@ -15547,6 +16756,7 @@
     zip: '84111'
     latitude: 40.7686249
     longitude: -111.8789585
+    id: S001192-salt_lake_city
   - address: 253 W. St George Blvd.
     building: ''
     city: St. George
@@ -15558,6 +16768,7 @@
     zip: '84770'
     latitude: 37.10961350000001
     longitude: -113.5887467
+    id: S001192-st__george
 - id:
     bioguide: S001193
     govtrack: 412514
@@ -15574,6 +16785,7 @@
     zip: '94546'
     latitude: 37.6950519
     longitude: -122.0722708
+    id: S001193-castro_valley
 - id:
     bioguide: S001194
     govtrack: 412507
@@ -15590,6 +16802,7 @@
     zip: '96850'
     latitude: 21.3036893
     longitude: -157.862353
+    id: S001194-honolulu
 - id:
     bioguide: S001195
     govtrack: 412596
@@ -15606,6 +16819,7 @@
     zip: '63703'
     latitude: 37.30292850000001
     longitude: -89.55584789999999
+    id: S001195-cape_girardeau
   - address: 22 E. Columbia St.
     building: ''
     city: Farmington
@@ -15617,6 +16831,7 @@
     zip: '63640'
     latitude: 37.7803665
     longitude: -90.4203215
+    id: S001195-farmington
   - address: 2725 N. Westwood Blvd.
     building: ''
     city: Poplar Bluff
@@ -15628,6 +16843,7 @@
     zip: '63901'
     latitude: 36.7847526
     longitude: -90.4294579
+    id: S001195-poplar_bluff
   - address: 830A S. Bishop
     building: ''
     city: Rolla
@@ -15639,6 +16855,7 @@
     zip: '65401'
     latitude: 37.9315472
     longitude: -91.7789873
+    id: S001195-rolla
   - address: 35 Court Sq.
     building: ''
     city: West Plains
@@ -15650,6 +16867,7 @@
     zip: '65775'
     latitude: 36.7283104
     longitude: -91.8529136
+    id: S001195-west_plains
 - id:
     bioguide: S001196
     govtrack: 412648
@@ -15666,6 +16884,7 @@
     zip: '12801'
     latitude: 43.3091113
     longitude: -73.6439247
+    id: S001196-glens_falls
   - address: 23 Durkee St.
     building: ''
     city: Plattsburgh
@@ -15677,6 +16896,7 @@
     zip: '12901'
     latitude: 44.6964439
     longitude: -73.45244749999999
+    id: S001196-plattsburgh
   - address: 88 Public Sq.
     building: ''
     city: Watertown
@@ -15688,6 +16908,7 @@
     zip: '13601'
     latitude: 43.974587
     longitude: -75.907664
+    id: S001196-watertown
 - id:
     bioguide: S001197
     govtrack: 412671
@@ -15704,6 +16925,7 @@
     zip: '68845'
     latitude: 40.715284
     longitude: -99.086211
+    id: S001197-kearney
   - address: 1128 Lincoln Mall.
     building: ''
     city: Lincoln
@@ -15715,6 +16937,7 @@
     zip: '68508'
     latitude: 40.8084319
     longitude: -96.7048142
+    id: S001197-lincoln
   - address: 304 N. 168th Cir.
     building: ''
     city: Omaha
@@ -15726,6 +16949,7 @@
     zip: '68118'
     latitude: 41.2618733
     longitude: -96.1778064
+    id: S001197-omaha
   - address: 115 Railway St.
     building: ''
     city: Scottsbluff
@@ -15737,6 +16961,7 @@
     zip: '69361'
     latitude: 41.8624626
     longitude: -103.6650529
+    id: S001197-scottsbluff
 - id:
     bioguide: S001198
     govtrack: 412665
@@ -15753,6 +16978,7 @@
     zip: '99501'
     latitude: 61.2171561
     longitude: -149.9043364
+    id: S001198-anchorage
   - address: 101 12th Ave.
     building: Federal Building
     city: Fairbanks
@@ -15764,6 +16990,7 @@
     zip: '99701'
     latitude: 64.8383052
     longitude: -147.7082477
+    id: S001198-fairbanks
   - address: 800 Glacier Ave.
     building: ''
     city: Juneau
@@ -15775,6 +17002,7 @@
     zip: '99801'
     latitude: 58.30033239999999
     longitude: -134.4205554
+    id: S001198-juneau
   - address: 805 Frontage Rd.
     building: ''
     city: Kenai
@@ -15786,6 +17014,7 @@
     zip: '99611'
     latitude: 60.55401089999999
     longitude: -151.2577208
+    id: S001198-kenai
   - address: 1900 First Ave.
     building: ''
     city: Ketchikan
@@ -15797,6 +17026,7 @@
     zip: '99901'
     latitude: 55.3492023
     longitude: -131.6673863
+    id: S001198-ketchikan
   - address: 851 E. Westpoint Dr.
     building: ''
     city: Wasilla
@@ -15808,6 +17038,7 @@
     zip: '99654'
     latitude: 61.5826697
     longitude: -149.4286826
+    id: S001198-wasilla
 - id:
     bioguide: S001199
     govtrack: 412722
@@ -15823,6 +17054,7 @@
     zip: '17602'
     latitude: 40.03689079999999
     longitude: -76.3031804
+    id: S001199-lancaster
 - id:
     bioguide: S001200
     govtrack: 412695
@@ -15838,6 +17070,7 @@
     zip: '34741'
     latitude: 28.2906297
     longitude: -81.4123113
+    id: S001200-kissimmee
 - id:
     bioguide: S001201
     govtrack: 412717
@@ -15853,6 +17086,7 @@
     zip: '11743'
     latitude: 40.873976
     longitude: -73.41131899999999
+    id: S001201-huntington
 - id:
     bioguide: T000193
     govtrack: 400402
@@ -15869,6 +17103,7 @@
     zip: '39041'
     latitude: 32.348821
     longitude: -90.459947
+    id: T000193-bolton
   - address: 910 Courthouse Ln.
     building: ''
     city: Greenville
@@ -15880,6 +17115,7 @@
     zip: '38701'
     latitude: 33.4079337
     longitude: -91.051782
+    id: T000193-greenville
   - address: 509 Highway 82 West
     building: ''
     city: Greenwood
@@ -15891,6 +17127,7 @@
     zip: '38930'
     latitude: 33.5051438
     longitude: -90.1865523
+    id: T000193-greenwood
   - address: 3607 Medgar Evers Blvd.
     building: ''
     city: Jackson
@@ -15902,6 +17139,7 @@
     zip: '39213'
     latitude: 32.339995
     longitude: -90.214478
+    id: T000193-jackson
   - address: 263 E. Main St.
     building: ''
     city: Marks
@@ -15913,6 +17151,7 @@
     zip: '38646'
     latitude: 34.2568675
     longitude: -90.2711465
+    id: T000193-marks
   - address: 106 Green Avenue
     building: ''
     city: Mound Bayou
@@ -15924,6 +17163,7 @@
     zip: '38762'
     latitude: 33.8783982
     longitude: -90.7298777
+    id: T000193-mound_bayou
 - id:
     bioguide: T000238
     govtrack: 400404
@@ -15940,6 +17180,7 @@
     zip: '79101'
     latitude: 35.2067762
     longitude: -101.8362037
+    id: T000238-amarillo
   - address: 2525 Kell Blvd.
     building: ''
     city: Wichita Falls
@@ -15951,6 +17192,7 @@
     zip: '76308'
     latitude: 33.8845789
     longitude: -98.527689
+    id: T000238-wichita_falls
 - id:
     bioguide: T000250
     govtrack: 400546
@@ -15967,6 +17209,7 @@
     zip: '57401'
     latitude: 45.4614099
     longitude: -98.4898984
+    id: T000250-aberdeen
   - address: 246 Founders Park Dr.
     building: ''
     city: Rapid City
@@ -15978,6 +17221,7 @@
     zip: '57701'
     latitude: 44.0872508
     longitude: -103.239745
+    id: T000250-rapid_city
   - address: 5015 S. Oak
     building: ''
     city: Sioux Falls
@@ -15989,6 +17233,7 @@
     zip: '57108'
     latitude: 43.4995298
     longitude: -96.76391439999999
+    id: T000250-sioux_falls
 - id:
     bioguide: T000460
     govtrack: 400403
@@ -16005,6 +17250,7 @@
     zip: '94558'
     latitude: 38.2491248
     longitude: -122.2743897
+    id: T000460-napa
   - address: 2300 County Center Dr.
     building: ''
     city: Santa Rosa
@@ -16016,6 +17262,7 @@
     zip: '95403'
     latitude: 38.4620056
     longitude: -122.7253838
+    id: T000460-santa_rosa
   - address: 985 Walnut Ave.
     building: ''
     city: Vallejo
@@ -16027,6 +17274,7 @@
     zip: '94592'
     latitude: 38.0989522
     longitude: -122.2728556
+    id: T000460-vallejo
 - id:
     bioguide: T000461
     govtrack: 400408
@@ -16043,6 +17291,7 @@
     zip: '18103'
     latitude: 40.569891
     longitude: -75.519529
+    id: T000461-allentown
   - address: 17 S. Park Row.
     building: United States Federal Building
     city: Erie
@@ -16054,6 +17303,7 @@
     zip: '16501'
     latitude: 42.1289745
     longitude: -80.08406889999999
+    id: T000461-erie
   - address: 228 Walnut St.
     building: United States Federal Building
     city: Harrisburg
@@ -16065,6 +17315,7 @@
     zip: '17101'
     latitude: 40.261919
     longitude: -76.882739
+    id: T000461-harrisburg
   - address: 1628 John F. Kennedy Blvd
     building: 8 Penn Center
     city: Philadelphia
@@ -16076,6 +17327,7 @@
     zip: '19103'
     latitude: 39.953754
     longitude: -75.167981
+    id: T000461-philadelphia
   - address: 100 W. Station Square Dr.
     building: ''
     city: Pittsburgh
@@ -16087,6 +17339,7 @@
     zip: '15219'
     latitude: 40.433674
     longitude: -80.003871
+    id: T000461-pittsburgh
   - address: 538 Spruce Street
     building: ''
     city: Scranton
@@ -16098,6 +17351,7 @@
     zip: '18503'
     latitude: 41.407372
     longitude: -75.662826
+    id: T000461-scranton
   - address: 1397 Eisenhower Blvd 
     building: Richland Square III
     city: Johnstown
@@ -16109,6 +17363,7 @@
     zip: '15904'
     latitude: 40.273143
     longitude: -78.848055
+    id: T000461-johnstown
 - id:
     bioguide: T000462
     govtrack: 400406
@@ -16125,6 +17380,7 @@
     zip: '43085'
     latitude: 40.1107173
     longitude: -83.00746439999999
+    id: T000462-worthington
 - id:
     bioguide: T000463
     govtrack: 400411
@@ -16141,6 +17397,7 @@
     zip: '45402'
     latitude: 39.7586771
     longitude: -84.19453349999999
+    id: T000463-dayton
 - id:
     bioguide: T000464
     govtrack: 412244
@@ -16157,6 +17414,7 @@
     zip: '59101'
     latitude: 45.783552
     longitude: -108.509375
+    id: T000464-billings
   - address: 1 E. Main St.
     building: ''
     city: Bozeman
@@ -16168,6 +17426,7 @@
     zip: '59715'
     latitude: 45.6795093
     longitude: -111.0370333
+    id: T000464-bozeman
   - address: 125 W. Granite
     building: Silver Bow Center
     city: Butte
@@ -16179,6 +17438,7 @@
     zip: '59701'
     latitude: 46.01461
     longitude: -112.538136
+    id: T000464-butte
   - address: 122 W. Towne St.
     building: ''
     city: Glendive
@@ -16190,6 +17450,7 @@
     zip: '59330'
     latitude: 47.106025
     longitude: -104.7135
+    id: T000464-glendive
   - address: 119 1st Ave.
     building: ''
     city: Great falls
@@ -16201,6 +17462,7 @@
     zip: '59401'
     latitude: 47.5065688
     longitude: -111.3040376
+    id: T000464-great_falls
   - address: 208 N. Montana Ave.
     building: Capital One Center
     city: Helena
@@ -16212,6 +17474,7 @@
     zip: '59601'
     latitude: 46.5865426
     longitude: -112.020799
+    id: T000464-helena
   - address: 8 Third St.
     building: ''
     city: Kalispell
@@ -16223,6 +17486,7 @@
     zip: '59901'
     latitude: 48.1958316
     longitude: -114.3128666
+    id: T000464-kalispell
   - address: 130 W. Front St.
     building: ''
     city: Missoula
@@ -16234,6 +17498,7 @@
     zip: '59802'
     latitude: 46.8704714
     longitude: -113.9961779
+    id: T000464-missoula
 - id:
     bioguide: T000465
     govtrack: 412254
@@ -16250,6 +17515,7 @@
     zip: '01420'
     latitude: 42.5815108
     longitude: -71.7931826
+    id: T000465-fitchburg
   - address: 10 Welcome St.
     building: ''
     city: Haverhill
@@ -16261,6 +17527,7 @@
     zip: '01830'
     latitude: 42.77661579999999
     longitude: -71.07887760000001
+    id: T000465-haverhill
   - address: 15 Union St.
     building: ''
     city: Lawrence
@@ -16272,6 +17539,7 @@
     zip: '01852'
     latitude: 42.70729679999999
     longitude: -71.1530981
+    id: T000465-lawrence
   - address: 126 John St.
     building: ''
     city: Lowell
@@ -16283,6 +17551,7 @@
     zip: '01852'
     latitude: 42.6482229
     longitude: -71.3081499
+    id: T000465-lowell
   - address: 255 Main St.
     building: Frank D. Walker Building
     city: Marlborough
@@ -16294,6 +17563,7 @@
     zip: '01752'
     latitude: 42.3465853
     longitude: -71.55200359999999
+    id: T000465-marlborough
 - id:
     bioguide: T000467
     govtrack: 412317
@@ -16310,6 +17580,7 @@
     zip: '16823'
     latitude: 40.8956202
     longitude: -77.7877153
+    id: T000467-bellefonte
   - address: 127 W. Spring St.
     building: ''
     city: Titusville
@@ -16321,6 +17592,7 @@
     zip: '16354'
     latitude: 41.6261989
     longitude: -79.6749289
+    id: T000467-titusville
 - id:
     bioguide: T000468
     govtrack: 412318
@@ -16337,6 +17609,7 @@
     zip: '89104'
     latitude: 36.1584562
     longitude: -115.1462019
+    id: T000468-las_vegas
 - id:
     bioguide: T000469
     govtrack: 412319
@@ -16353,6 +17626,7 @@
     zip: '12210'
     latitude: 42.6553697
     longitude: -73.7616111
+    id: T000469-albany
   - address: 61 Church St.
     building: ''
     city: Amsterdam
@@ -16364,6 +17638,7 @@
     zip: '12010'
     latitude: 42.9387067
     longitude: -74.1884752
+    id: T000469-amsterdam
   - address: 105 Jay St.
     building: ''
     city: Schenectady
@@ -16375,6 +17650,7 @@
     zip: '12305'
     latitude: 42.8143015
     longitude: -73.9398087
+    id: T000469-schenectady
 - id:
     bioguide: T000470
     govtrack: 412405
@@ -16391,6 +17667,7 @@
     zip: '81101'
     latitude: 37.4685012
     longitude: -105.8659434
+    id: T000470-alamosa
   - address: 835 E. Second Ave.
     building: ''
     city: Durango
@@ -16402,6 +17679,7 @@
     zip: '81301'
     latitude: 37.2725939
     longitude: -107.8799634
+    id: T000470-durango
   - address: 225 N. 5th St.
     building: ''
     city: Grand Junction
@@ -16413,6 +17691,7 @@
     zip: '81501'
     latitude: 39.0688046
     longitude: -108.5648398
+    id: T000470-grand_junction
   - address: 503 N. Main St.
     building: ''
     city: Pueblo
@@ -16424,6 +17703,7 @@
     zip: '81003'
     latitude: 38.27203069999999
     longitude: -104.60937
+    id: T000470-pueblo
 - id:
     bioguide: T000472
     govtrack: 412520
@@ -16440,6 +17720,7 @@
     zip: '92501'
     latitude: 33.9787895
     longitude: -117.3724531
+    id: T000472-riverside
 - id:
     bioguide: T000474
     govtrack: 412617
@@ -16456,6 +17737,7 @@
     zip: '91764'
     latitude: 34.0707079
     longitude: -117.5807122
+    id: T000474-ontario
 - id:
     bioguide: T000475
     govtrack: 412636
@@ -16472,6 +17754,7 @@
     zip: '48083'
     latitude: 42.563685
     longitude: -83.13596580000001
+    id: T000475-troy
 - id:
     bioguide: T000476
     govtrack: 412668
@@ -16488,6 +17771,7 @@
     zip: '28269'
     latitude: 35.34589709999999
     longitude: -80.8466732
+    id: T000476-charlotte
   - address: 1694 E. Arlington Blvd.
     building: ''
     city: Greenville
@@ -16499,6 +17783,7 @@
     zip: '27858'
     latitude: 35.5709032
     longitude: -77.3592441
+    id: T000476-greenville
   - address: 1 Historic Courthouse Sq.
     building: Suite 112
     city: Hendersonville
@@ -16510,6 +17795,7 @@
     zip: '28792'
     latitude: 35.3145365
     longitude: -82.46020910000001
+    id: T000476-hendersonville
   - address: 1840 Eastchester Dr.
     building: ''
     city: High Point
@@ -16521,6 +17807,7 @@
     zip: '27265'
     latitude: 36.008425
     longitude: -79.98567299999999
+    id: T000476-high_point
   - address: 310 New Bern Ave.
     building: ''
     city: Raleigh
@@ -16532,6 +17819,7 @@
     zip: '27601'
     latitude: 35.7799621
     longitude: -78.63388100000002
+    id: T000476-raleigh
 - id:
     bioguide: T000478
     govtrack: 412720
@@ -16547,6 +17835,7 @@
     zip: '13413'
     latitude: 43.0900861
     longitude: -75.2786079
+    id: T000478-new_hartford
 - id:
     bioguide: U000031
     govtrack: 400414
@@ -16563,6 +17852,7 @@
     zip: '49007'
     latitude: 42.2926475
     longitude: -85.57910969999999
+    id: U000031-kalamazoo
   - address: 720 Main St.
     building: ''
     city: St. Joseph
@@ -16574,6 +17864,7 @@
     zip: '49085'
     latitude: 42.105351
     longitude: -86.48403499999999
+    id: U000031-st__joseph
 - id:
     bioguide: U000039
     govtrack: 400413
@@ -16590,6 +17881,7 @@
     zip: '87102'
     latitude: 35.0833514
     longitude: -106.6521937
+    id: U000039-albuquerque
   - address: 102 W. Hagerman St.
     building: ''
     city: Carlsbad
@@ -16601,6 +17893,7 @@
     zip: '88220'
     latitude: 32.425358
     longitude: -104.226611
+    id: U000039-carlsbad
   - address: 201 N. Church St.
     building: ''
     city: Las Cruces
@@ -16612,6 +17905,7 @@
     zip: '88001'
     latitude: 32.3109784
     longitude: -106.7786459
+    id: U000039-las_cruces
   - address: 100 South Avenue A
     building: ''
     city: Portales
@@ -16623,6 +17917,7 @@
     zip: '88130'
     latitude: 34.1859741
     longitude: -103.3381861
+    id: U000039-portales
   - address: 120 S. Federal Pl.
     building: ''
     city: Santa Fe
@@ -16634,6 +17929,7 @@
     zip: '87501'
     latitude: 35.6913389
     longitude: -105.938628
+    id: U000039-santa_fe
 - id:
     bioguide: V000081
     govtrack: 400416
@@ -16650,6 +17946,7 @@
     zip: '11211'
     latitude: 40.7085893
     longitude: -73.9592284
+    id: V000081-brooklyn
   - address: 16 Court St.
     building: ''
     city: Brooklyn
@@ -16661,6 +17958,7 @@
     zip: '11241'
     latitude: 40.6936024
     longitude: -73.9908511
+    id: V000081-brooklyn-1
   - address: 500 Pearl St.
     building: ''
     city: New York
@@ -16672,6 +17970,7 @@
     zip: '10007'
     latitude: 40.7137324
     longitude: -74.00080179999999
+    id: V000081-new_york
 - id:
     bioguide: V000108
     govtrack: 400417
@@ -16688,6 +17987,7 @@
     zip: '46410'
     latitude: 41.4752503
     longitude: -87.3354152
+    id: V000108-merrillville
 - id:
     bioguide: V000129
     govtrack: 412515
@@ -16704,6 +18004,7 @@
     zip: '93301'
     latitude: 35.3835765
     longitude: -119.0145887
+    id: V000129-bakersfield
   - address: 101 N. Irwin St.
     building: ''
     city: Hanford
@@ -16715,6 +18016,7 @@
     zip: '93230'
     latitude: 36.3257372
     longitude: -119.646568
+    id: V000129-hanford
 - id:
     bioguide: V000130
     govtrack: 412522
@@ -16731,6 +18033,7 @@
     zip: '91910'
     latitude: 32.6410939
     longitude: -117.0811877
+    id: V000130-chula_vista
   - address: 380 N. 8th St.
     building: ''
     city: El Centro
@@ -16742,6 +18045,7 @@
     zip: '92243'
     latitude: 32.7956143
     longitude: -115.5618357
+    id: V000130-el_centro
 - id:
     bioguide: V000131
     govtrack: 412579
@@ -16758,6 +18062,7 @@
     zip: '75208'
     latitude: 32.7687234
     longitude: -96.8364642
+    id: V000131-dallas
   - address: 6707 Brentwood Stair Rd.
     building: ''
     city: Fort Worth
@@ -16769,6 +18074,7 @@
     zip: '76112'
     latitude: 32.7547849
     longitude: -97.21394939999999
+    id: V000131-fort_worth
 - id:
     bioguide: V000132
     govtrack: 412580
@@ -16785,6 +18091,7 @@
     zip: '78332'
     latitude: 27.7499027
     longitude: -98.0720001
+    id: V000132-alice
   - address: 333 Ebony Ave.
     building: ''
     city: Brownsville
@@ -16796,6 +18103,7 @@
     zip: '78520'
     latitude: 25.9156491
     longitude: -97.4918723
+    id: V000132-brownsville
   - address: 1390 W. Expressway 83
     building: ''
     city: San Benito
@@ -16807,6 +18115,7 @@
     zip: '78586'
     latitude: 26.1404901
     longitude: -97.65383639999999
+    id: V000132-san_benito
   - address: 500 S. Kansas Ave.
     building: ''
     city: Weslaco
@@ -16818,6 +18127,7 @@
     zip: '78596'
     latitude: 26.157205
     longitude: -97.989865
+    id: V000132-weslaco
 - id:
     bioguide: W000187
     govtrack: 400422
@@ -16834,6 +18144,7 @@
     zip: '90003'
     latitude: 33.94388
     longitude: -118.2777646
+    id: W000187-los_angeles
 - id:
     bioguide: W000437
     govtrack: 400432
@@ -16850,6 +18161,7 @@
     zip: '39501'
     latitude: 30.3665745
     longitude: -89.0969882
+    id: W000437-gulfport
   - address: 321 Losher St.
     building: ''
     city: Hernando
@@ -16861,6 +18173,7 @@
     zip: '38632'
     latitude: 34.822334
     longitude: -89.994967
+    id: W000437-hernando
   - address: 501 E. Court St.
     building: ''
     city: Jackson
@@ -16872,6 +18185,7 @@
     zip: '39201'
     latitude: 32.294793
     longitude: -90.1837769
+    id: W000437-jackson
   - address: 330 W. Jefferson St.
     building: ''
     city: Tupelo
@@ -16883,6 +18197,7 @@
     zip: '38804'
     latitude: 34.2594314
     longitude: -88.70673479999999
+    id: W000437-tupelo
 - id:
     bioguide: W000779
     govtrack: 300100
@@ -16899,6 +18214,7 @@
     zip: '97701'
     latitude: 44.0577537
     longitude: -121.3095974
+    id: W000779-bend
   - address: 405 E. 8th Ave.
     building: ''
     city: Eugene
@@ -16910,6 +18226,7 @@
     zip: '97401'
     latitude: 44.0516985
     longitude: -123.0857882
+    id: W000779-eugene
   - address: 105 Fir St.
     building: SAC Annex Building
     city: La Grande
@@ -16921,6 +18238,7 @@
     zip: '97850'
     latitude: 45.326715
     longitude: -118.0926554
+    id: W000779-la_grande
   - address: 310 W. 6th St.
     building: Federal Courthouse
     city: Medford
@@ -16932,6 +18250,7 @@
     zip: '97501'
     latitude: 42.3253466
     longitude: -122.8769125
+    id: W000779-medford
   - address: 911 11th Ave.
     building: ''
     city: Portland
@@ -16943,6 +18262,7 @@
     zip: '97232'
     latitude: 45.5293348
     longitude: -122.6555902
+    id: W000779-portland
   - address: 707 13th St.
     building: ''
     city: Salem
@@ -16954,6 +18274,7 @@
     zip: '97301'
     latitude: 44.9304368
     longitude: -123.0290967
+    id: W000779-salem
 - id:
     bioguide: W000791
     govtrack: 400419
@@ -16970,6 +18291,7 @@
     zip: '97701'
     latitude: 44.0598422
     longitude: -121.3117677
+    id: W000791-bend
   - address: 1211 Washington Ave.
     building: ''
     city: La Grande
@@ -16981,6 +18303,7 @@
     zip: '97850'
     latitude: 45.3276926
     longitude: -118.0948731
+    id: W000791-la_grande
   - address: 14 N. Central Ave.
     building: ''
     city: Medford
@@ -16992,6 +18315,7 @@
     zip: '97501'
     latitude: 42.3270103
     longitude: -122.8722747
+    id: W000791-medford
 - id:
     bioguide: W000795
     govtrack: 400433
@@ -17008,6 +18332,7 @@
     zip: '29801'
     latitude: 33.5823882
     longitude: -81.72758859999999
+    id: W000795-aiken
   - address: 1700 Sunset Blvd.
     building: ''
     city: West Columbia
@@ -17019,6 +18344,7 @@
     zip: '29169'
     latitude: 33.9993356
     longitude: -81.0889668
+    id: W000795-west_columbia
 - id:
     bioguide: W000797
     govtrack: 400623
@@ -17035,6 +18361,7 @@
     zip: '33180'
     latitude: 25.9528671
     longitude: -80.1390699
+    id: W000797-aventura
   - address: 777 Sawgrass Corporate Parkway
     building: ''
     city: Sunrise
@@ -17046,6 +18373,7 @@
     zip: '33325'
     latitude: 26.130384
     longitude: -80.333636
+    id: W000797-sunrise
 - id:
     bioguide: W000798
     govtrack: 412213
@@ -17062,6 +18390,7 @@
     zip: '49201'
     latitude: 42.247186
     longitude: -84.414954
+    id: W000798-jackson
 - id:
     bioguide: W000799
     govtrack: 412214
@@ -17078,6 +18407,7 @@
     zip: '56001'
     latitude: 44.16288429999999
     longitude: -94.0067275
+    id: W000799-mankato
   - address: 1202 ½ 7th Street NW
     building: ''
     city: Rochester
@@ -17089,6 +18419,7 @@
     zip: '55901'
     latitude: 44.0316171
     longitude: -92.4806419
+    id: W000799-rochester
 - id:
     bioguide: W000800
     govtrack: 412239
@@ -17105,6 +18436,7 @@
     zip: '05401'
     latitude: 44.4626812
     longitude: -73.21776830000002
+    id: W000800-burlington
 - id:
     bioguide: W000802
     govtrack: 412247
@@ -17121,6 +18453,7 @@
     zip: '02903'
     latitude: 41.8235873
     longitude: -71.4113021
+    id: W000802-providence
 - id:
     bioguide: W000804
     govtrack: 412255
@@ -17137,6 +18470,7 @@
     zip: '22556'
     latitude: 38.4781455
     longitude: -77.4211435
+    id: W000804-stafford
   - address: 508 Church Lane
     building: ''
     city: Tappahannock
@@ -17148,6 +18482,7 @@
     zip: '22560'
     latitude: 37.9307412
     longitude: -76.8625874
+    id: W000804-tappahannock
   - address: 401 Main St.
     building: ''
     city: Yorktown
@@ -17159,6 +18494,7 @@
     zip: '23690'
     latitude: 37.2353811
     longitude: -76.5083854
+    id: W000804-yorktown
 - id:
     bioguide: W000805
     govtrack: 412321
@@ -17175,6 +18511,7 @@
     zip: '24210'
     latitude: 36.7095562
     longitude: -81.9767798
+    id: W000805-abingdon
   - address: 101 W. Main St.
     building: ''
     city: Norfolk
@@ -17186,6 +18523,7 @@
     zip: '23510'
     latitude: 36.8461399
     longitude: -76.293138
+    id: W000805-norfolk
   - address: 919 E. Main St.
     building: ''
     city: Richmond
@@ -17197,6 +18535,7 @@
     zip: '23219'
     latitude: 37.5374358
     longitude: -77.4362913
+    id: W000805-richmond
   - address: 110 Kirk Ave.
     building: ''
     city: Roanoke
@@ -17208,6 +18547,7 @@
     zip: '24011'
     latitude: 37.270958
     longitude: -79.942561
+    id: W000805-roanoke
   - address: 8000 Towers Crescent Dr.
     building: ''
     city: Vienna
@@ -17219,6 +18559,7 @@
     zip: '22182'
     latitude: 38.9145473
     longitude: -77.2196271
+    id: W000805-vienna
 - id:
     bioguide: W000806
     govtrack: 412410
@@ -17235,6 +18576,7 @@
     zip: '34450'
     latitude: 28.8363417
     longitude: -82.3321296
+    id: W000806-inverness
   - address: 800 Us Hwy.
     building: ''
     city: Minneola
@@ -17246,6 +18588,7 @@
     zip: '34715'
     latitude: 28.5886193
     longitude: -81.752927
+    id: W000806-minneola
   - address: 8015 E County Rd 466
     building: ''
     city: The Villages
@@ -17257,6 +18600,7 @@
     zip: '32162'
     latitude: 28.9188822
     longitude: -81.970805
+    id: W000806-the_villages
 - id:
     bioguide: W000808
     govtrack: 412412
@@ -17273,6 +18617,7 @@
     zip: '33169'
     latitude: 25.9436377
     longitude: -80.20465759999999
+    id: W000808-miami_gardens
   - address: 2300 Civic Ctr.
     building: Miramar City Hall
     city: Miramar
@@ -17284,6 +18629,7 @@
     zip: '33025'
     latitude: 25.9869532
     longitude: -80.3010666
+    id: W000808-miramar
   - address: 1965 South State Road 7
     building: West Park City Hall
     city: West Park
@@ -17295,6 +18641,7 @@
     zip: '33023'
     latitude: 25.993095
     longitude: -80.2038997
+    id: W000808-west_park
 - id:
     bioguide: W000809
     govtrack: 412402
@@ -17311,6 +18658,7 @@
     zip: '72902'
     latitude: 35.391425
     longitude: -94.421624
+    id: W000809-fort_smith
   - address: 303 N. Main St.
     building: ''
     city: Harrison
@@ -17322,6 +18670,7 @@
     zip: '72601'
     latitude: 36.2326224
     longitude: -93.1068643
+    id: W000809-harrison
   - address: 3333 Pinnacle Hls.
     building: ''
     city: Rogers
@@ -17333,6 +18682,7 @@
     zip: '72758'
     latitude: 36.3046472
     longitude: -94.18675220000002
+    id: W000809-rogers
 - id:
     bioguide: W000810
     govtrack: 412416
@@ -17347,6 +18697,7 @@
     state: GA
     suite: ''
     zip: 30046-6935
+    id: W000810-lawrenceville
 - id:
     bioguide: W000812
     govtrack: 412548
@@ -17363,6 +18714,7 @@
     zip: '63011'
     latitude: 38.5980031
     longitude: -90.4902674
+    id: W000812-ballwin
 - id:
     bioguide: W000813
     govtrack: 412538
@@ -17379,6 +18731,7 @@
     zip: '46544'
     latitude: 41.6614853
     longitude: -86.1788818
+    id: W000813-mishawaka
   - address: 709 Main St.
     building: ''
     city: Rochester
@@ -17390,6 +18743,7 @@
     zip: '46975'
     latitude: 41.06708709999999
     longitude: -86.21585259999999
+    id: W000813-rochester
 - id:
     bioguide: W000814
     govtrack: 412574
@@ -17406,6 +18760,7 @@
     zip: '77701'
     latitude: 30.0825032
     longitude: -94.098555
+    id: W000814-beaumont
   - address: 122 West Way
     building: ''
     city: Lake Jackson
@@ -17417,6 +18772,7 @@
     zip: '77566'
     latitude: 29.0445713
     longitude: -95.4537198
+    id: W000814-lake_jackson
   - address: 174 Calder Rd.
     building: Suite 150
     city: League City
@@ -17428,6 +18784,7 @@
     zip: '77573'
     latitude: 29.5035441
     longitude: -95.1045214
+    id: W000814-league_city
 - id:
     bioguide: W000815
     govtrack: 412564
@@ -17444,6 +18801,7 @@
     zip: '45245'
     latitude: 39.0911309
     longitude: -84.2738952
+    id: W000815-cincinnati
   - address: 7954 Beechmont Ave.
     building: ''
     city: Cincinnati
@@ -17455,6 +18813,7 @@
     zip: '45255'
     latitude: 39.0731109
     longitude: -84.3352704
+    id: W000815-cincinnati-1
   - address: 170 N. Main St.
     building: ''
     city: Peebles
@@ -17466,6 +18825,7 @@
     zip: '45660'
     latitude: 38.9507705
     longitude: -83.404366
+    id: W000815-peebles
 - id:
     bioguide: W000816
     govtrack: 412578
@@ -17482,6 +18842,7 @@
     zip: '78701'
     latitude: 30.2720399
     longitude: -97.7409012
+    id: W000816-austin
   - address: 115 S. Main St.
     building: ''
     city: Cleburne
@@ -17493,6 +18854,7 @@
     zip: '76033'
     latitude: 32.3462862
     longitude: -97.3858312
+    id: W000816-cleburne
 - id:
     bioguide: W000817
     govtrack: 412542
@@ -17509,6 +18871,7 @@
     zip: '02203'
     latitude: 42.3613091
     longitude: -71.0593927
+    id: W000817-boston
   - address: 1550 Main St.
     building: ''
     city: Springfield
@@ -17520,6 +18883,7 @@
     zip: '01103'
     latitude: 42.10321649999999
     longitude: -72.5929441
+    id: W000817-springfield
 - id:
     bioguide: W000819
     govtrack: 412670
@@ -17536,6 +18900,7 @@
     zip: '27253'
     latitude: 36.069812
     longitude: -79.403882
+    id: W000819-graham
   - address: 809 Green Valley Rd.
     building: ''
     city: Greensboro
@@ -17547,6 +18912,7 @@
     zip: '27408'
     latitude: 36.092294
     longitude: -79.81627999999999
+    id: W000819-greensboro
 - id:
     bioguide: W000820
     govtrack: 412618
@@ -17563,6 +18929,7 @@
     zip: '92612'
     latitude: 33.6725307
     longitude: -117.8438666
+    id: W000820-irvine
 - id:
     bioguide: W000821
     govtrack: 412610
@@ -17579,6 +18946,7 @@
     zip: '71730'
     latitude: 33.2122274
     longitude: -92.6633531
+    id: W000821-el_dorado
   - address: 101 Reserve St.
     building: ''
     city: Hot Springs
@@ -17590,6 +18958,7 @@
     zip: '71901'
     latitude: 34.5131753
     longitude: -93.05133239999999
+    id: W000821-hot_springs
   - address: 211 W. Commercial St.
     building: ''
     city: Ozark
@@ -17601,6 +18970,7 @@
     zip: '72949'
     latitude: 35.4864789
     longitude: -93.8267906
+    id: W000821-ozark
   - address: 100 E. 8th Ave.
     building: ''
     city: Pine Bluff
@@ -17612,6 +18982,7 @@
     zip: '71601'
     latitude: 34.2211366
     longitude: -92.0026041
+    id: W000821-pine_bluff
 - id:
     bioguide: W000822
     govtrack: 412644
@@ -17628,6 +18999,7 @@
     zip: '08628'
     latitude: 40.2793143
     longitude: -74.8302945
+    id: W000822-ewing
 - id:
     bioguide: Y000033
     govtrack: 400440
@@ -17644,6 +19016,7 @@
     zip: '99503'
     latitude: 61.1821567
     longitude: -149.8834942
+    id: Y000033-anchorage
   - address: 100 Cushman St.
     building: ''
     city: Fairbanks
@@ -17655,6 +19028,7 @@
     zip: '99707'
     latitude: 64.84351649999999
     longitude: -147.7220032
+    id: Y000033-fairbanks
 - id:
     bioguide: Y000062
     govtrack: 412211
@@ -17671,6 +19045,7 @@
     zip: '40202'
     latitude: 38.2486082
     longitude: -85.7622452
+    id: Y000062-louisville
 - id:
     bioguide: Y000063
     govtrack: 412430
@@ -17687,6 +19062,7 @@
     zip: '66204'
     latitude: 38.98588549999999
     longitude: -94.6703158
+    id: Y000063-overland_park
 - id:
     bioguide: Y000065
     govtrack: 412525
@@ -17703,6 +19079,7 @@
     zip: '32606'
     latitude: 29.678553
     longitude: -82.39626
+    id: Y000065-gainesville
   - address: 35 Knight Boxx Rd.
     building: ''
     city: Orange Park
@@ -17714,6 +19091,7 @@
     zip: '32065'
     latitude: 30.1208794
     longitude: -81.7974322
+    id: Y000065-orange_park
 - id:
     bioguide: Y000066
     govtrack: 412628
@@ -17730,6 +19108,7 @@
     zip: '51503'
     latitude: 41.256851
     longitude: -95.85104799999999
+    id: Y000066-council_bluffs
   - address: 208 W. Taylor St.
     building: ''
     city: Creston
@@ -17741,6 +19120,7 @@
     zip: '50801'
     latitude: 41.0485652
     longitude: -94.36330889999999
+    id: Y000066-creston
   - address: 601 E. Locust St.
     building: ''
     city: Des Moines
@@ -17752,6 +19132,7 @@
     zip: '50309'
     latitude: 41.589826
     longitude: -93.6093349
+    id: Y000066-des_moines
 - id:
     bioguide: Z000017
     govtrack: 412646
@@ -17768,6 +19149,7 @@
     zip: '11901'
     latitude: 40.9172285
     longitude: -72.6627645
+    id: Z000017-riverhead
   - address: 31 Oak St.
     building: ''
     city: Patchogue
@@ -17779,6 +19161,7 @@
     zip: '11772'
     latitude: 40.7671697
     longitude: -73.0138358
+    id: Z000017-patchogue
 - id:
     bioguide: Z000018
     govtrack: 412640
@@ -17795,6 +19178,7 @@
     zip: '59101'
     latitude: 45.7810512
     longitude: -108.5125313
+    id: Z000018-billings
   - address: 710 Central Ave.
     building: ''
     city: Great Falls
@@ -17806,6 +19190,7 @@
     zip: '59401'
     latitude: 47.5050157
     longitude: -111.2947656
+    id: Z000018-great_falls
   - address: 910 N. Gulch
     building: ''
     city: Helena
@@ -17817,6 +19202,7 @@
     zip: '59601'
     latitude: 46.5971339
     longitude: -112.0330044
+    id: Z000018-helena
   - address: 1008 South Ave.
     building: ''
     city: Missoula
@@ -17828,6 +19214,7 @@
     zip: '59801'
     latitude: 46.8490726
     longitude: -114.0137795
+    id: Z000018-missoula
 - id:
     bioguide: H001075
     govtrack: 412678
@@ -17844,6 +19231,7 @@
     zip: '95814'
     latitude: 38.583455
     longitude: -121.4987519
+    id: H001075-sacramento
   - address: 2500 Tulare Street
     building: ''
     city: Fresno
@@ -17855,6 +19243,7 @@
     zip: '93721'
     latitude: 36.7374775
     longitude: -119.7836709
+    id: H001075-fresno
   - address: 312 N. Spring St.
     building: ''
     city: Los Angeles
@@ -17866,6 +19255,7 @@
     zip: '90012'
     latitude: 34.0552049
     longitude: -118.241422
+    id: H001075-los_angeles
   - address: 50 United Nations Plaza
     building: ''
     city: San Francisco
@@ -17877,6 +19267,7 @@
     zip: '94102'
     latitude: 37.7804298
     longitude: -122.4144643
+    id: H001075-san_francisco
   - address: 600 B Street
     building: ''
     city: San Diego
@@ -17888,6 +19279,7 @@
     zip: '92101'
     latitude: 32.7182014
     longitude: -117.1587103
+    id: H001075-san_diego
 - id:
     bioguide: Y000064
     thomas: '02019'
@@ -17904,6 +19296,7 @@
     zip: '46204'
     latitude: 39.770723
     longitude: -86.15702999999999
+    id: Y000064-indianapolis
   - address: 121 West Spring Street
     building: ''
     city: New Albany
@@ -17915,6 +19308,7 @@
     zip: '47150'
     latitude: 38.2850131
     longitude: -85.82465959999999
+    id: Y000064-new_albany
   - address: 101 Martin Luther King Jr. Blvd
     building: ''
     city: Evansville
@@ -17926,6 +19320,7 @@
     zip: '47708'
     latitude: 37.975188
     longitude: -87.567486
+    id: Y000064-evansville
   - address: 1300 South Harrison Street
     building: ''
     city: Fort Wayne
@@ -17937,6 +19332,7 @@
     zip: '46802'
     latitude: 41.0737372
     longitude: -85.14045349999999
+    id: Y000064-fort_wayne
 - id:
     govtrack: 412533
     bioguide: D000622
@@ -17953,6 +19349,7 @@
     zip: '60604'
     latitude: 41.8784454
     longitude: -87.63
+    id: D000622-chicago
 - id:
     bioguide: H001076
     govtrack: 412680
@@ -17968,6 +19365,7 @@
     zip: '03101'
     latitude: 42.995106
     longitude: -71.463785
+    id: H001076-manchester
 - id:
     bioguide: C001113
     govtrack: 412681
@@ -17983,6 +19381,7 @@
     zip: '89101'
     latitude: 36.1651058
     longitude: -115.1424211
+    id: C001113-las_vegas
   - address: 400 South Virginia Street
     building: Courthouse and Federal Building
     city: Reno
@@ -17994,6 +19393,7 @@
     zip: '89501'
     latitude: 39.5215352
     longitude: -119.810287
+    id: C001113-reno
 - id:
     bioguide: B001301
     govtrack: 412709
@@ -18009,6 +19409,7 @@
     zip: '49696'
     latitude: 44.7066718
     longitude: -85.5961732
+    id: B001301-traverse_city
 - id:
     bioguide: E000297
     govtrack: 412718
@@ -18024,6 +19425,7 @@
     zip: '10027'
     latitude: 40.8092343
     longitude: -73.9474317
+    id: E000297-new_york
   - address: 2530 Grand Concourse Avenue
     building: ''
     city: Bronx
@@ -18035,6 +19437,7 @@
     zip: '10458'
     latitude: 40.863512
     longitude: -73.895791
+    id: E000297-bronx
 - id:
     bioguide: C001111
     govtrack: 412697
@@ -18050,4 +19453,4 @@
     zip: '33701'
     latitude: 27.772067
     longitude: -82.643550
-
+    id: C001111-st__petersburg


### PR DESCRIPTION
This modifies the `legislators-district-offices.yaml` file to add a unique `id` field to each office record. The purpose is to make it easier for clients ingesting the data to update their records when the file changes.

The ID is comprised of the legislator's bioguide ID, the name of the city the office is in, and an optional integer for disambiguation.