### PR TITLE
Add missing offices for J000299, L000586

### DIFF
--- a/legislators-district-offices.yaml
+++ b/legislators-district-offices.yaml
@@ -8748,6 +8748,30 @@
     latitude: 32.5579513
     longitude: -93.7228425
     id: J000299-bossier_city
+  - address: 444 Caspari Dr.
+    building: ''
+    city: Natchitoches
+    fax: ''
+    hours: ''
+    phone: 318-357-5731
+    state: LA
+    suite: South Hall Room 224
+    zip: '71497'
+    latitude: 31.7479383
+    longitude: -93.0970551
+    id: J000299-natchitoches
+  - address: 3329 University Parkway
+    building: Building 552
+    city: Leesville
+    fax: ''
+    hours: ''
+    phone: 337-392-3146
+    state: LA
+    suite: Room 24
+    zip: '71446'
+    latitude: 31.0884912
+    longitude: -93.2312895
+    id: J000299-leesville
 - id:
     bioguide: K000009
     govtrack: 400211
@@ -10634,6 +10658,18 @@
     latitude: 30.4463425
     longitude: -84.28819759999999
     id: L000586-tallahassee
+  - address: 1010 N. Davis St.
+    building: ''
+    city: Jacksonville
+    fax: 904-379-0309
+    hours: ''
+    phone: 904-354-1652
+    state: FL
+    suite: Suite 206
+    zip: '32209'
+    latitude: 30.336823
+    longitude: -81.667581
+    id: L000586-jacksonville
 - id:
     bioguide: L000587
     govtrack: 412711


### PR DESCRIPTION
Added missing offices per the official websites for [Al Lawson](https://lawson.house.gov/) and [Mike Johnson](https://mikejohnson.house.gov/)