### PR TITLE
Capitalize "Ada" in city value for C001053-ada

### DIFF
--- a/legislators-district-offices.yaml
+++ b/legislators-district-offices.yaml
@@ -2842,7 +2842,7 @@
     id: C001053-norman
   - address: 100 E. 13th St.
     building: ''
-    city: ada
+    city: Ada
     fax: 580-436-5451
     hours: ''
     phone: 580-436-5375


### PR DESCRIPTION
Hi guys,

First - thank you for compiling this data and making it freely available under the same license as the upstream repo. This is an extremely valuable data set and I'm sure it was no small effort to compile it.

While pulling some of this data into a recent side project I noticed that a city value for an Oklahoma office wasn't capitalized. This PR fixes that.

Thanks again.

-Andrew