### PR TITLE
Update Eleanor Holmes Norton's offices

### DIFF
--- a/legislators-district-offices.yaml
+++ b/legislators-district-offices.yaml
@@ -12668,7 +12668,7 @@
     govtrack: 400295
     thomas: '00868'
   offices:
-  - address: 90 K St.
+  - address: 90 K St. NE
     building: ''
     city: Washington
     fax: 202-408-9048
@@ -12680,14 +12680,14 @@
     latitude: 38.9031719
     longitude: -77.00662319999999
     id: N000147-washington
-  - address: 2041 Martin Luther King Jr Ave.
+  - address: 2235 Shannon Place SE
     building: ''
     city: Washington
     fax: 202-678-8844
     hours: M-F 9-5:30pm
     phone: 202-678-8900
     state: DC
-    suite: Suite 238
+    suite: Suite 2032-A
     zip: '20020'
     latitude: 38.8659837
     longitude: -76.9897997


### PR DESCRIPTION
As part of my spot checking today I noticed that Eleanor Holmes Norton's DC offices were missing quadrants in their street addresses.

https://norton.house.gov/contact/offices

It appears she also moved her SE district office. I added the new address.

Thanks again.