### PR TITLE
Fix ZIP+4 for Carolyn Maloney's Brooklyn office

### DIFF
--- a/legislators-district-offices.yaml
+++ b/legislators-district-offices.yaml
@@ -10712,7 +10712,7 @@
     phone: 718-349-5972
     state: NY
     suite: ''
-    zip: 11211-222
+    zip: 11211-2228
     latitude: 40.7155784
     longitude: -73.94987139999999
     id: M000087-brooklyn


### PR DESCRIPTION
Correct ZIP+4 found on the footer of http://maloney.house.gov/