### PR TITLE
Cory Gardner office updates

### DIFF
--- a/legislators-district-offices.yaml
+++ b/legislators-district-offices.yaml
@@ -6772,29 +6772,29 @@
     latitude: 38.83199949999999
     longitude: -104.8240571
     id: G000562-colorado_springs
-  - address: 1125 17th St.
+  - address: 721 19th St.
     building: ''
     city: Denver
     fax: 202-228-7171
     hours: ''
     phone: 303-391-5777
     state: CO
-    suite: Ste. 525
+    suite: Ste. 150
     zip: '80202'
-    latitude: 39.7494865
-    longitude: -104.994834
+    latitude: 39.7485943
+    longitude: -104.9908558
     id: G000562-denver
-  - address: 329 Rio
+  - address: 329 S. Camino Del Rio
     building: ''
     city: Durango
     fax: 970-259-4276
     hours: ''
-    phone: 970-259-1231
+    phone: 970-415-7416
     state: CO
-    suite: ''
+    suite: Ste. I
     zip: '81303'
-    latitude: 37.2509136
-    longitude: -107.8778701
+    latitude: 37.2508296
+    longitude: -107.880109
     id: G000562-durango
   - address: 2001 S. Shields St.
     building: Building H
@@ -6809,13 +6809,13 @@
     longitude: -105.0969106
     id: G000562-fort_collins
   - address: 400 Rood Ave.
-    building: Federal Bldg., Ste. 220
+    building: Federal Bldg.
     city: Grand Junction
     fax: 202-228-7173
     hours: ''
     phone: 970-245-9553
     state: CO
-    suite: ''
+    suite: Ste. 220
     zip: '81501'
     latitude: 39.06856490000001
     longitude: -108.5657085


### PR DESCRIPTION
Sen. Gardner has moved his Denver office. Also, a couple of other updates to his information. 

All addresses are at the bottom of: https://www.gardner.senate.gov/.